### PR TITLE
Update changelog and move frontend code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,21 @@ All notable changes to the "mybatis-boost" extension will be documented in this 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+## [0.0.1] - Initial Release
 
 ### Added
+- ✨ **10 types of Go-to-Definition navigation** (F12/Ctrl+Click):
+  1. Java interface name → XML `<mapper>` tag
+  2. Java method name → XML SQL statement
+  3. XML namespace attribute → Java interface
+  4. XML statement ID → Java method
+  5. Java class references in XML → Java class definition
+  6. `<include refid>` → `<sql id>` fragment definition
+  7. `<sql id>` → All `<include>` references (shows all usages)
+  8. `<result property>` → Java class field definition
+  9. `resultMap` reference ↔ `<resultMap>` definition (bidirectional)
+  10. XML parameters (`#{paramName}`, `${paramName}`) → Java field or `@Param` annotation
+
 - ✨ **Parameter Validation**: Real-time validation of `#{param}` and `${param}` references in XML mapper files
   - Validates against `parameterType` class fields
   - Validates against method parameters with `@Param` annotations
@@ -17,12 +29,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
   - Supports nested properties (e.g., `#{user.name}` validates base object `user`)
   - Works across `<select>`, `<insert>`, `<update>`, `<delete>` statements
   - Automatic validation on file open, change, and save
-
-- ✨ **Parameter Navigation**: Go-to-Definition (F12) from XML parameters to Java (Type 10)
-  - Navigate from `#{paramName}` to Java class field in `parameterType` class
-  - Navigate from `#{paramName}` to `@Param` annotation in method parameters
-  - Supports nested properties navigation
-  - Full parameter parser implementation
 
 - ✨ **Flexible Navigation Modes**: Choose between CodeLens or DefinitionProvider
   - **CodeLens Mode** (default, recommended): Non-invasive, preserves native Java F12 behavior
@@ -47,34 +53,17 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
   - `xmlParser.ts`: Multi-line tags, precise position tracking
   - `parameterParser.ts`: Parameter references, local variables, nested properties
 
+- ✨ **Visual binding indicators** - gutter icons show Java methods ↔ XML statement bindings
+- ✨ **LRU cache** with configurable size (default: 5000 entries)
+- ✨ **Automatic cache invalidation** on file changes
+- ✨ **File system watchers** for incremental updates
+- ✨ **Smart MyBatis mapper detection** (content-based, not just filename)
+- ✨ **5-tier intelligent XML file matching strategy**
+- ✨ **Custom XML directories support** (Priority 1 in matching)
+- ✨ **Multi-line tag parsing support**
+- ✨ **Configurable settings**
+
 ### Fixed
 - 🐛 **Navigation Precision**: XML statement to Java method navigation now only works when cursor is specifically on the `id="methodName"` attribute. Previously, clicking anywhere inside the statement block would trigger navigation, which was too permissive and could cause unintended navigation.
 - 🐛 **API Usage**: Fixed incorrect usage of `getByXmlPath()` - now correctly uses `getJavaPath()` API method
 - 🐛 **Command Invocation**: Fixed `jumpToXml` command to work with both CodeLens and manual invocation, with proper cursor position detection
-
-### Changed
-- 📝 **Default Navigation Mode**: Changed default from DefinitionProvider to CodeLens to preserve native Java navigation behavior
-- ⚡ **Performance**: Improved parser performance with better caching and lazy loading
-
-## [0.0.1] - Initial Release
-
-### Added
-- ✨ **9 types of Go-to-Definition navigation** (F12/Ctrl+Click):
-  1. Java interface name → XML `<mapper>` tag
-  2. Java method name → XML SQL statement
-  3. XML namespace attribute → Java interface
-  4. XML statement ID → Java method
-  5. Java class references in XML → Java class definition
-  6. `<include refid>` → `<sql id>` fragment definition
-  7. `<sql id>` → All `<include>` references (shows all usages)
-  8. `<result property>` → Java class field definition
-  9. `resultMap` reference ↔ `<resultMap>` definition (bidirectional)
-- ✨ Visual binding indicators - gutter icons show Java methods ↔ XML statement bindings
-- ✨ LRU cache with configurable size (default: 5000 entries)
-- ✨ Automatic cache invalidation on file changes
-- ✨ File system watchers for incremental updates
-- ✨ Smart MyBatis mapper detection (content-based, not just filename)
-- ✨ 5-tier intelligent XML file matching strategy
-- ✨ Custom XML directories support (Priority 1 in matching)
-- ✨ Multi-line tag parsing support
-- ✨ Configurable settings

--- a/CHANGELOG.zh-cn.md
+++ b/CHANGELOG.zh-cn.md
@@ -6,9 +6,21 @@
 
 查看 [Keep a Changelog](http://keepachangelog.com/) 了解如何组织此文件的建议。
 
-## [未发布]
+## [0.0.1] - 初始版本
 
 ### 新增
+- ✨ **10 种跳转到定义的导航方式**（F12/Ctrl+点击）：
+  1. Java 接口名称 → XML `<mapper>` 标签
+  2. Java 方法名称 → XML SQL 语句
+  3. XML 命名空间属性 → Java 接口
+  4. XML 语句 ID → Java 方法
+  5. XML 中的 Java 类引用 → Java 类定义
+  6. `<include refid>` → `<sql id>` 片段定义
+  7. `<sql id>` → 所有 `<include>` 引用（显示所有用法）
+  8. `<result property>` → Java 类字段定义
+  9. `resultMap` 引用 ↔ `<resultMap>` 定义（双向）
+  10. XML 参数（`#{paramName}`、`${paramName}`）→ Java 字段或 `@Param` 注解
+
 - ✨ **参数验证**：对 XML 映射器文件中的 `#{param}` 和 `${param}` 引用进行实时验证
   - 针对 `parameterType` 类字段进行验证
   - 针对带有 `@Param` 注解的方法参数进行验证
@@ -17,12 +29,6 @@
   - 支持嵌套属性（例如，`#{user.name}` 验证基础对象 `user`）
   - 适用于 `<select>`、`<insert>`、`<update>`、`<delete>` 语句
   - 在文件打开、更改和保存时自动验证
-
-- ✨ **参数导航**：从 XML 参数跳转到 Java（F12）（类型 10）
-  - 从 `#{paramName}` 导航到 `parameterType` 类中的 Java 类字段
-  - 从 `#{paramName}` 导航到方法参数中的 `@Param` 注解
-  - 支持嵌套属性导航
-  - 完整的参数解析器实现
 
 - ✨ **灵活的导航模式**：在 CodeLens 或 DefinitionProvider 之间选择
   - **CodeLens 模式**（默认，推荐）：非侵入式，保留原生 Java F12 行为
@@ -47,34 +53,17 @@
   - `xmlParser.ts`：多行标签、精确位置跟踪
   - `parameterParser.ts`：参数引用、局部变量、嵌套属性
 
+- ✨ **可视化绑定指示器** - 装订线图标显示 Java 方法 ↔ XML 语句绑定
+- ✨ **可配置大小的 LRU 缓存**（默认：5000 条目）
+- ✨ **文件更改时自动缓存失效**
+- ✨ **用于增量更新的文件系统监视器**
+- ✨ **智能 MyBatis 映射器检测**（基于内容，而非仅文件名）
+- ✨ **5 层智能 XML 文件匹配策略**
+- ✨ **自定义 XML 目录支持**（匹配中的优先级 1）
+- ✨ **多行标签解析支持**
+- ✨ **可配置设置**
+
 ### 修复
 - 🐛 **导航精度**：XML 语句到 Java 方法的导航现在仅在光标特别位于 `id="methodName"` 属性时才有效。以前，在语句块内的任何地方点击都会触发导航，这太宽松了，可能会导致意外导航。
 - 🐛 **API 使用**：修复了对 `getByXmlPath()` 的错误使用 - 现在正确使用 `getJavaPath()` API 方法
 - 🐛 **命令调用**：修复了 `jumpToXml` 命令，使其可以与 CodeLens 和手动调用一起使用，并具有正确的光标位置检测
-
-### 更改
-- 📝 **默认导航模式**：将默认值从 DefinitionProvider 更改为 CodeLens，以保留原生 Java 导航行为
-- ⚡ **性能**：通过更好的缓存和延迟加载提高了解析器性能
-
-## [0.0.1] - 初始版本
-
-### 新增
-- ✨ **9 种跳转到定义的导航方式**（F12/Ctrl+点击）：
-  1. Java 接口名称 → XML `<mapper>` 标签
-  2. Java 方法名称 → XML SQL 语句
-  3. XML 命名空间属性 → Java 接口
-  4. XML 语句 ID → Java 方法
-  5. XML 中的 Java 类引用 → Java 类定义
-  6. `<include refid>` → `<sql id>` 片段定义
-  7. `<sql id>` → 所有 `<include>` 引用（显示所有用法）
-  8. `<result property>` → Java 类字段定义
-  9. `resultMap` 引用 ↔ `<resultMap>` 定义（双向）
-- ✨ 可视化绑定指示器 - 装订线图标显示 Java 方法 ↔ XML 语句绑定
-- ✨ 可配置大小的 LRU 缓存（默认：5000 条目）
-- ✨ 文件更改时自动缓存失效
-- ✨ 用于增量更新的文件系统监视器
-- ✨ 智能 MyBatis 映射器检测（基于内容，而非仅文件名）
-- ✨ 5 层智能 XML 文件匹配策略
-- ✨ 自定义 XML 目录支持（匹配中的优先级 1）
-- ✨ 多行标签解析支持
-- ✨ 可配置设置


### PR DESCRIPTION
- Moved all unreleased features from [Unreleased] section to [0.0.1]
- Updated navigation types count from 9 to 10 (added parameter navigation)
- Consolidated parameter validation, flexible navigation modes, CodeLens provider, and enhanced parsers into initial release
- Applied changes to both English (CHANGELOG.md) and Chinese (CHANGELOG.zh-cn.md) versions