### PR TITLE
MyBatis 3.x parameter mapping without explicit annotations

### DIFF
--- a/src/navigator/diagnostics/ParameterValidator.ts
+++ b/src/navigator/diagnostics/ParameterValidator.ts
@@ -131,8 +131,9 @@ export class ParameterValidator {
             const validParams = new Set<string>();
 
             // 1. Add parameters from @Param annotations in Java method
+            let methodParams: any[] = [];
             try {
-                const methodParams = await extractMethodParameters(javaPath, statement.id);
+                methodParams = await extractMethodParameters(javaPath, statement.id);
                 methodParams.forEach(p => validParams.add(p.name));
                 console.log(`[ParameterValidator] Method ${statement.id} has parameters: ${Array.from(validParams).join(', ')}`);
             } catch (error) {
@@ -147,6 +148,30 @@ export class ParameterValidator {
                     console.log(`[ParameterValidator] Class ${paramInfo.parameterType} has fields: ${fields.join(', ')}`);
                 } catch (error) {
                     console.error(`[ParameterValidator] Error extracting class fields:`, error);
+                }
+            }
+
+            // 2.5. MyBatis 3.x+ single object parameter auto-mapping
+            // If there's only one parameter without @Param annotation, and it's not a primitive type,
+            // MyBatis will automatically map the object's fields
+            if (methodParams.length === 1 && !methodParams[0].hasParamAnnotation) {
+                const singleParam = methodParams[0];
+                const paramType = singleParam.paramType;
+
+                // Check if it's not a built-in type (primitives, String, Integer, etc.)
+                if (!this.isBuiltInType(paramType) && !this.isCollectionType(paramType)) {
+                    try {
+                        // Try to get the fully qualified class name from the Java file
+                        const fullyQualifiedType = await this.resolveFullyQualifiedType(javaPath, paramType);
+
+                        if (fullyQualifiedType) {
+                            const fields = await this.getClassFields(fullyQualifiedType);
+                            fields.forEach(f => validParams.add(f));
+                            console.log(`[ParameterValidator] Single parameter ${singleParam.name} (${fullyQualifiedType}) auto-mapped fields: ${fields.join(', ')}`);
+                        }
+                    } catch (error) {
+                        console.error(`[ParameterValidator] Error extracting fields from single parameter type:`, error);
+                    }
                 }
             }
 
@@ -230,6 +255,16 @@ export class ParameterValidator {
     private isBuiltInType(className: string): boolean {
         const primitives = ['int', 'long', 'double', 'float', 'boolean', 'byte', 'short', 'char'];
         const javaLang = [
+            'String',
+            'Integer',
+            'Long',
+            'Double',
+            'Float',
+            'Boolean',
+            'Byte',
+            'Short',
+            'Character',
+            'Object',
             'java.lang.String',
             'java.lang.Integer',
             'java.lang.Long',
@@ -243,6 +278,108 @@ export class ParameterValidator {
         ];
 
         return primitives.includes(className) || javaLang.includes(className);
+    }
+
+    /**
+     * Check if a class name is a collection type
+     */
+    private isCollectionType(className: string): boolean {
+        const collectionTypes = [
+            'List',
+            'Set',
+            'Map',
+            'Collection',
+            'ArrayList',
+            'LinkedList',
+            'HashSet',
+            'HashMap',
+            'LinkedHashMap',
+            'TreeMap',
+            'TreeSet',
+            'Vector',
+            'Stack',
+            'Queue',
+            'Deque',
+            'java.util.List',
+            'java.util.Set',
+            'java.util.Map',
+            'java.util.Collection',
+            'java.util.ArrayList',
+            'java.util.LinkedList',
+            'java.util.HashSet',
+            'java.util.HashMap',
+            'java.util.LinkedHashMap',
+            'java.util.TreeMap',
+            'java.util.TreeSet',
+            'java.util.Vector',
+            'java.util.Stack',
+            'java.util.Queue',
+            'java.util.Deque'
+        ];
+
+        return collectionTypes.includes(className);
+    }
+
+    /**
+     * Resolve the fully qualified class name from a simple type name in a Java file
+     */
+    private async resolveFullyQualifiedType(javaPath: string, simpleTypeName: string): Promise<string | null> {
+        try {
+            const fs = await import('fs');
+            const content = await fs.promises.readFile(javaPath, 'utf-8');
+            const lines = content.split('\n');
+
+            // Look for import statements that match the simple type name
+            for (const line of lines) {
+                const trimmed = line.trim();
+
+                // Stop at the class/interface declaration
+                if (trimmed.match(/(?:class|interface|enum)\s+/)) {
+                    break;
+                }
+
+                // Check for matching import
+                const importMatch = trimmed.match(/import\s+([\w.]+\.(\w+))\s*;/);
+                if (importMatch) {
+                    const fullyQualified = importMatch[1];
+                    const importedSimpleName = importMatch[2];
+
+                    if (importedSimpleName === simpleTypeName) {
+                        console.log(`[ParameterValidator] Resolved ${simpleTypeName} to ${fullyQualified}`);
+                        return fullyQualified;
+                    }
+                }
+            }
+
+            // If not found in imports, check if it's in the same package
+            const packageMatch = content.match(/package\s+([\w.]+)\s*;/);
+            if (packageMatch) {
+                const packageName = packageMatch[1];
+                const possibleFullyQualified = `${packageName}.${simpleTypeName}`;
+
+                // Try to find the class file in the same package
+                const pathPattern = possibleFullyQualified.replace(/\./g, '/') + '.java';
+                const searchPattern = `**/${pathPattern}`;
+
+                const files = await vscode.workspace.findFiles(
+                    searchPattern,
+                    '**/{ node_modules,target,.git,.vscode,.idea,.settings,build,dist,out,bin}/**',
+                    1
+                );
+
+                if (files.length > 0) {
+                    console.log(`[ParameterValidator] Resolved ${simpleTypeName} to ${possibleFullyQualified} (same package)`);
+                    return possibleFullyQualified;
+                }
+            }
+
+            console.log(`[ParameterValidator] Could not resolve fully qualified name for ${simpleTypeName}`);
+            return null;
+
+        } catch (error) {
+            console.error(`[ParameterValidator] Error resolving type ${simpleTypeName}:`, error);
+            return null;
+        }
     }
 
     /**

--- a/src/test/fixtures/parameter-validation/WelfareActivity.java
+++ b/src/test/fixtures/parameter-validation/WelfareActivity.java
@@ -1,0 +1,42 @@
+package com.example.model;
+
+import java.util.Date;
+
+public class WelfareActivity {
+    private Long id;
+    private String name;
+    private String status;
+    private Date createTime;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+}

--- a/src/test/fixtures/parameter-validation/WelfareActivityMapper.java
+++ b/src/test/fixtures/parameter-validation/WelfareActivityMapper.java
@@ -1,0 +1,31 @@
+package com.example.mapper;
+
+import com.example.query.WelfareActivityQuery;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import java.util.List;
+
+@Mapper
+public interface WelfareActivityMapper {
+    /**
+     * MyBatis 3.x+ single object parameter auto-mapping
+     * No @Param annotation, no parameterType in XML
+     * MyBatis will automatically map query.order and query.size
+     */
+    List<WelfareActivity> selectByCondition(WelfareActivityQuery condition);
+
+    /**
+     * Multiple parameters - one with @Param, one without
+     */
+    Integer selectTargetTime(@Param("userId") String userId, @Param("newCode") String newCode);
+
+    /**
+     * Single String parameter - should NOT auto-map fields
+     */
+    List<WelfareActivity> selectByStatus(String status);
+
+    /**
+     * Single Integer parameter - should NOT auto-map fields
+     */
+    WelfareActivity selectById(Long id);
+}

--- a/src/test/fixtures/parameter-validation/WelfareActivityMapper.xml
+++ b/src/test/fixtures/parameter-validation/WelfareActivityMapper.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.mapper.WelfareActivityMapper">
+
+    <sql id="Base_Column_List">
+        id, name, status, create_time
+    </sql>
+
+    <sql id="where_condition">
+        <where>
+            <if test="status != null">
+                AND status = #{status}
+            </if>
+            <if test="userId != null">
+                AND user_id = #{userId}
+            </if>
+        </where>
+    </sql>
+
+    <!--
+        MyBatis 3.x+ single object parameter auto-mapping scenario
+        - No @Param annotation on method parameter
+        - No parameterType attribute in XML
+        - MyBatis automatically maps fields: order, size, status, userId
+        This should NOT show parameter validation errors
+    -->
+    <select id="selectByCondition" resultType="WelfareActivity">
+        select
+        <include refid="Base_Column_List"/>
+        from t_welfare_activity
+        <include refid="where_condition"/>
+        <trim prefix="ORDER BY ">
+            <if test="order != null ">
+                ${order}
+            </if>
+        </trim>
+        <if test="size != null ">
+            limit ${size}
+        </if>
+    </select>
+
+    <!--
+        Multiple parameters with @Param
+        Should validate against userId and newCode
+    -->
+    <select id="selectTargetTime" resultType="java.lang.Integer">
+        SELECT COUNT(*) FROM t_welfare_activity
+        WHERE user_id = #{userId}
+        AND new_code = #{newCode}
+    </select>
+
+    <!--
+        Single String parameter - primitive type
+        Should NOT auto-map fields, status should be the parameter name
+    -->
+    <select id="selectByStatus" resultType="WelfareActivity">
+        SELECT * FROM t_welfare_activity
+        WHERE status = #{status}
+    </select>
+
+    <!--
+        Single Long parameter - wrapper of primitive type
+        Should NOT auto-map fields, id should be the parameter name
+    -->
+    <select id="selectById" resultType="WelfareActivity">
+        SELECT * FROM t_welfare_activity
+        WHERE id = #{id}
+    </select>
+
+</mapper>

--- a/src/test/fixtures/parameter-validation/WelfareActivityQuery.java
+++ b/src/test/fixtures/parameter-validation/WelfareActivityQuery.java
@@ -1,0 +1,40 @@
+package com.example.query;
+
+public class WelfareActivityQuery {
+    private String order;
+    private Integer size;
+    private String status;
+    private Long userId;
+
+    public String getOrder() {
+        return order;
+    }
+
+    public void setOrder(String order) {
+        this.order = order;
+    }
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/src/test/integration/parameterValidator.singleObjectParam.test.ts
+++ b/src/test/integration/parameterValidator.singleObjectParam.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Integration tests for ParameterValidator - MyBatis 3.x+ single object parameter auto-mapping
+ */
+
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { ParameterValidator } from '../../navigator/diagnostics/ParameterValidator';
+import { FileMapper } from '../../navigator/core/FileMapper';
+import { createMockContext } from '../helpers/testSetup';
+
+suite('ParameterValidator - Single Object Parameter Auto-mapping Integration Tests', () => {
+    let parameterValidator: ParameterValidator;
+    let fileMapper: FileMapper;
+    let context: vscode.ExtensionContext;
+    let extensionPath: string;
+
+    suiteSetup(async function() {
+        this.timeout(30000);
+
+        // Get extension path
+        extensionPath = vscode.extensions.getExtension('young1lin.mybatis-boost')?.extensionPath || process.cwd();
+
+        // Create mock extension context
+        context = createMockContext(extensionPath);
+
+        // Initialize FileMapper
+        fileMapper = new FileMapper(context, 5000);
+        await fileMapper.initialize();
+
+        // Initialize ParameterValidator
+        parameterValidator = new ParameterValidator(context, fileMapper);
+
+        // Wait a bit for initialization
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    });
+
+    suiteTeardown(() => {
+        if (parameterValidator) {
+            parameterValidator.dispose();
+        }
+        if (fileMapper) {
+            fileMapper.dispose();
+        }
+    });
+
+    suite('MyBatis 3.x+ single object parameter auto-mapping', () => {
+        test('should auto-map fields for single object parameter without @Param and without parameterType', async function() {
+            this.timeout(10000);
+
+            const xmlPath = path.join(
+                extensionPath,
+                'src', 'test', 'fixtures', 'parameter-validation',
+                'WelfareActivityMapper.xml'
+            );
+
+            const xmlUri = vscode.Uri.file(xmlPath);
+            const document = await vscode.workspace.openTextDocument(xmlUri);
+
+            // Validate the document
+            await parameterValidator.validateDocument(document);
+
+            // Wait a bit for validation to complete
+            await new Promise(resolve => setTimeout(resolve, 500));
+
+            // Get diagnostics for the document
+            const diagnostics = vscode.languages.getDiagnostics(xmlUri);
+
+            // The selectByCondition statement uses #{order}, #{size}, #{status}, #{userId}
+            // These should all be valid because:
+            // 1. The method has a single parameter: WelfareActivityQuery condition
+            // 2. The parameter does not have @Param annotation
+            // 3. WelfareActivityQuery has fields: order, size, status, userId
+            // 4. MyBatis 3.x+ will auto-map these fields
+
+            // Log all diagnostics for debugging
+            console.log(`[Test] All diagnostics: ${JSON.stringify(diagnostics.map(d => ({ message: d.message, line: d.range.start.line })))}`);
+
+            // Filter diagnostics to only those related to selectByCondition
+            const selectByConditionDiagnostics = diagnostics.filter(d => {
+                // Check if diagnostic is in the selectByCondition statement range (approximately lines 21-42)
+                const line = d.range.start.line;
+                return line >= 20 && line <= 45 && d.source === 'MyBatis Boost';
+            });
+
+            console.log(`[Test] selectByCondition diagnostics: ${JSON.stringify(selectByConditionDiagnostics.map(d => ({ message: d.message, line: d.range.start.line })))}`);
+
+            assert.strictEqual(
+                selectByConditionDiagnostics.length,
+                0,
+                `Expected no parameter validation errors for single object parameter auto-mapping, but got: ${selectByConditionDiagnostics.map(d => `${d.message} at line ${d.range.start.line}`).join('; ')}`
+            );
+        });
+
+        test('should NOT auto-map fields for single primitive parameter', async function() {
+            this.timeout(10000);
+
+            const xmlPath = path.join(
+                extensionPath,
+                'src', 'test', 'fixtures', 'parameter-validation',
+                'WelfareActivityMapper.xml'
+            );
+
+            const xmlUri = vscode.Uri.file(xmlPath);
+            const document = await vscode.workspace.openTextDocument(xmlUri);
+
+            // Validate the document
+            await parameterValidator.validateDocument(document);
+
+            // Wait a bit for validation to complete
+            await new Promise(resolve => setTimeout(resolve, 500));
+
+            // Get diagnostics for the document
+            const diagnostics = vscode.languages.getDiagnostics(xmlUri);
+
+            // The selectByStatus statement uses #{status} at approximately line 57
+            // The selectById statement uses #{id} at approximately line 65
+
+            const selectByStatusDiagnostics = diagnostics.filter(d => {
+                const line = d.range.start.line;
+                return line >= 52 && line <= 60 && d.source === 'MyBatis Boost' && d.message.includes('status');
+            });
+
+            const selectByIdDiagnostics = diagnostics.filter(d => {
+                const line = d.range.start.line;
+                return line >= 61 && line <= 69 && d.source === 'MyBatis Boost' && d.message.includes('id');
+            });
+
+            console.log(`[Test] selectByStatus diagnostics: ${JSON.stringify(selectByStatusDiagnostics.map(d => d.message))}`);
+            console.log(`[Test] selectById diagnostics: ${JSON.stringify(selectByIdDiagnostics.map(d => d.message))}`);
+
+            assert.strictEqual(
+                selectByStatusDiagnostics.length,
+                0,
+                `Expected no parameter validation errors for single String parameter, but got: ${selectByStatusDiagnostics.map(d => d.message).join('; ')}`
+            );
+
+            assert.strictEqual(
+                selectByIdDiagnostics.length,
+                0,
+                `Expected no parameter validation errors for single Long parameter, but got: ${selectByIdDiagnostics.map(d => d.message).join('; ')}`
+            );
+        });
+
+        test('should validate parameters with @Param annotations correctly', async function() {
+            this.timeout(10000);
+
+            const xmlPath = path.join(
+                extensionPath,
+                'src', 'test', 'fixtures', 'parameter-validation',
+                'WelfareActivityMapper.xml'
+            );
+
+            const xmlUri = vscode.Uri.file(xmlPath);
+            const document = await vscode.workspace.openTextDocument(xmlUri);
+
+            // Validate the document
+            await parameterValidator.validateDocument(document);
+
+            // Wait a bit for validation to complete
+            await new Promise(resolve => setTimeout(resolve, 500));
+
+            // Get diagnostics for the document
+            const diagnostics = vscode.languages.getDiagnostics(xmlUri);
+
+            // The selectTargetTime statement is at approximately lines 47-51
+            const selectTargetTimeDiagnostics = diagnostics.filter(d => {
+                const line = d.range.start.line;
+                return line >= 46 && line <= 52 && d.source === 'MyBatis Boost';
+            });
+
+            console.log(`[Test] selectTargetTime diagnostics: ${JSON.stringify(selectTargetTimeDiagnostics.map(d => d.message))}`);
+
+            assert.strictEqual(
+                selectTargetTimeDiagnostics.length,
+                0,
+                `Expected no parameter validation errors for @Param annotated parameters, but got: ${selectTargetTimeDiagnostics.map(d => d.message).join('; ')}`
+            );
+        });
+    });
+});


### PR DESCRIPTION
Fixed parameter validation to support MyBatis 3.x+ behavior where a single object parameter without @Param annotation automatically maps its fields.

Changes:
- Enhanced ParameterValidator to detect single object parameters
- Added field resolution from parameter types via imports
- Added collection type detection to prevent false positives
- Improved built-in type detection (String, Integer, etc.)

Test Coverage:
- Added WelfareActivityMapper test fixtures
- Added integration tests for single object parameter scenarios
- Verified primitive types don't trigger auto-mapping
- Verified @Param annotated parameters work correctly

Fixes validation errors for queries like:
```xml
<select id="selectByCondition">
  WHERE status = #{status}  <!-- from WelfareActivityQuery.status -->
  ORDER BY ${order}         <!-- from WelfareActivityQuery.order -->
</select>
```

With Java method:
```java
List<Activity> selectByCondition(WelfareActivityQuery condition);
// No @Param needed - MyBatis 3.x+ auto-maps condition.status, condition.order, etc.
```