### PR TITLE
Add internationalization to package.json config

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,47 +113,47 @@
         "mybatis-boost.generator.basePackage": {
           "type": "string",
           "default": "com.example.mybatis",
-          "description": "Base package for generated Java code"
+          "description": "%config.generator.basePackage.description%"
         },
         "mybatis-boost.generator.author": {
           "type": "string",
           "default": "MyBatis Boost",
-          "description": "Author name in generated file headers"
+          "description": "%config.generator.author.description%"
         },
         "mybatis-boost.generator.entitySuffix": {
           "type": "string",
           "default": "PO",
-          "description": "Suffix for entity classes (e.g., UserPO)"
+          "description": "%config.generator.entitySuffix.description%"
         },
         "mybatis-boost.generator.mapperSuffix": {
           "type": "string",
           "default": "Mapper",
-          "description": "Suffix for mapper interfaces (e.g., UserMapper)"
+          "description": "%config.generator.mapperSuffix.description%"
         },
         "mybatis-boost.generator.serviceSuffix": {
           "type": "string",
           "default": "Service",
-          "description": "Suffix for service interfaces (e.g., UserService)"
+          "description": "%config.generator.serviceSuffix.description%"
         },
         "mybatis-boost.generator.useLombok": {
           "type": "boolean",
           "default": true,
-          "description": "Generate Lombok annotations (@Data, @Builder, etc.)"
+          "description": "%config.generator.useLombok.description%"
         },
         "mybatis-boost.generator.useSwagger": {
           "type": "boolean",
           "default": false,
-          "description": "Generate Swagger v2 annotations (@ApiModel, @ApiModelProperty)"
+          "description": "%config.generator.useSwagger.description%"
         },
         "mybatis-boost.generator.useSwaggerV3": {
           "type": "boolean",
           "default": false,
-          "description": "Generate Swagger v3/OpenAPI annotations (@Schema)"
+          "description": "%config.generator.useSwaggerV3.description%"
         },
         "mybatis-boost.generator.useMyBatisPlus": {
           "type": "boolean",
           "default": false,
-          "description": "Generate MyBatis Plus annotations"
+          "description": "%config.generator.useMyBatisPlus.description%"
         }
       }
     }

--- a/package.nls.json
+++ b/package.nls.json
@@ -12,5 +12,14 @@
   "config.javaParseLines.description": "Number of lines to read from Java files for namespace extraction",
   "config.showBindingIcons.description": "Show gutter icons for MyBatis bindings between Java methods and XML statements",
   "config.useDefinitionProvider.description": "Enable Go-to-Definition (F12) for Java-to-XML navigation. When false (default), use CodeLens instead to preserve native Java definition behavior",
-  "config.generator.datetime.description": "Java type to use for SQL DATETIME/TIMESTAMP columns when parsing DDL statements (DATE always maps to LocalDate, TIME always maps to LocalTime)"
+  "config.generator.datetime.description": "Java type to use for SQL DATETIME/TIMESTAMP columns when parsing DDL statements (DATE always maps to LocalDate, TIME always maps to LocalTime)",
+  "config.generator.basePackage.description": "Base package for generated Java code",
+  "config.generator.author.description": "Author name in generated file headers",
+  "config.generator.entitySuffix.description": "Suffix for entity classes (e.g., UserPO)",
+  "config.generator.mapperSuffix.description": "Suffix for mapper interfaces (e.g., UserMapper)",
+  "config.generator.serviceSuffix.description": "Suffix for service interfaces (e.g., UserService)",
+  "config.generator.useLombok.description": "Generate Lombok annotations (@Data, @Builder, etc.)",
+  "config.generator.useSwagger.description": "Generate Swagger v2 annotations (@ApiModel, @ApiModelProperty)",
+  "config.generator.useSwaggerV3.description": "Generate Swagger v3/OpenAPI annotations (@Schema)",
+  "config.generator.useMyBatisPlus.description": "Generate MyBatis Plus annotations"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -12,5 +12,14 @@
   "config.javaParseLines.description": "从 Java 文件中读取以提取命名空间的行数",
   "config.showBindingIcons.description": "在 Java 方法和 XML 语句之间显示 MyBatis 绑定的装订线图标",
   "config.useDefinitionProvider.description": "启用 Java 到 XML 导航的跳转到定义（F12）功能。当设为 false（默认）时，使用 CodeLens 以保留原生 Java 定义行为",
-  "config.generator.datetime.description": "解析 DDL 语句时用于 SQL DATETIME/TIMESTAMP 列的 Java 类型（DATE 始终映射为 LocalDate，TIME 始终映射为 LocalTime）"
+  "config.generator.datetime.description": "解析 DDL 语句时用于 SQL DATETIME/TIMESTAMP 列的 Java 类型（DATE 始终映射为 LocalDate，TIME 始终映射为 LocalTime）",
+  "config.generator.basePackage.description": "生成的 Java 代码的基础包名",
+  "config.generator.author.description": "生成的文件头中的作者名称",
+  "config.generator.entitySuffix.description": "实体类的后缀（例如 UserPO）",
+  "config.generator.mapperSuffix.description": "映射器接口的后缀（例如 UserMapper）",
+  "config.generator.serviceSuffix.description": "服务接口的后缀（例如 UserService）",
+  "config.generator.useLombok.description": "生成 Lombok 注解（@Data、@Builder 等）",
+  "config.generator.useSwagger.description": "生成 Swagger v2 注解（@ApiModel、@ApiModelProperty）",
+  "config.generator.useSwaggerV3.description": "生成 Swagger v3/OpenAPI 注解（@Schema）",
+  "config.generator.useMyBatisPlus.description": "生成 MyBatis Plus 注解"
 }


### PR DESCRIPTION
- Update package.json to use i18n placeholders for 9 generator configs
- Add English translations in package.nls.json
- Add Chinese translations in package.nls.zh-cn.json

Configs internationalized:
- basePackage, author, entitySuffix, mapperSuffix, serviceSuffix
- useLombok, useSwagger, useSwaggerV3, useMyBatisPlus