### PR TITLE
Reduce VSIX package size by removing images

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,3 +12,5 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
+images/demo.gif
+images/mcp.gif


### PR DESCRIPTION
- Exclude demo.gif (1.4M) and mcp.gif (1.6M) from package
- These files are only used in README documentation
- Reduced package size from ~3.2MB to 271KB (90% reduction)
- Retain only essential icons: MyBatis.png, MyBatis.svg, MyBatis-line.svg