### PR TITLE
Fix XML formatter to preserve selectKey tags and unknown closing tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to the "mybatis-boost" extension will be documented in this 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.3.14] - 2026-02-04
+
+### Fixed
+
+- 🔧 **XML Formatter selectKey Tag Support**: Fixed critical formatting bug where `<selectKey>` tags inside `<insert>` statements were completely destroyed during formatting
+  - **Problem**: `<selectKey keyProperty="id" order="AFTER" resultType="java.lang.Long">` was mangled to `< selectKey keyProperty = "id" ORDER = "AFTER"...>`, and all content after `</selectKey>` (including `<trim>` and `<if>` blocks) was lost entirely
+  - **Root Cause 1**: `selectKey` was missing from the CST parser's recognized dynamic tags list, causing it to be treated as raw SQL text and mangled by the SQL formatter
+  - **Root Cause 2**: The parser would break on ANY `</` closing tag sequence, not just known tags - so `</selectKey>` caused the parser to stop, losing all subsequent content
+  - **Solution**: Added `selectKey` to the recognized dynamic tags list and made the parser only break on closing tags of known dynamic tags
+  - Added 6 new unit tests for `<selectKey>` tag preservation and unknown closing tag robustness
+
+### Technical Details
+
+- **DYNAMIC_TAGS Update**: Added `selectkey` to the formatter's recognized tag list in `MybatisSqlFormatter.ts`
+- **Parser Robustness**: Updated `parseNodes()` and `parseText()` in the CST parser to peek ahead at closing tag names before breaking - unknown closing tags are now consumed as text instead of causing early termination
+- **Case Sensitivity**: Tag matching uses `.toLowerCase()` comparison, so `<selectKey>`, `<SelectKey>`, `<SELECTKEY>` all work correctly while preserving original case in output
+
 ## [0.3.13] - 2026-02-03
 
 ### Fixed

--- a/CHANGELOG.zh-cn.md
+++ b/CHANGELOG.zh-cn.md
@@ -6,6 +6,23 @@
 
 查看 [Keep a Changelog](http://keepachangelog.com/) 了解如何组织此文件的建议。
 
+## [0.3.14] - 2026-02-04
+
+### 修复
+
+- 🔧 **XML 格式化 selectKey 标签支持**：修复了 `<insert>` 语句中 `<selectKey>` 标签在格式化时被完全破坏的严重问题
+  - **问题**：`<selectKey keyProperty="id" order="AFTER" resultType="java.lang.Long">` 被格式化为 `< selectKey keyProperty = "id" ORDER = "AFTER"...>`，并且 `</selectKey>` 之后的所有内容（包括 `<trim>` 和 `<if>` 块）全部丢失
+  - **根本原因 1**：CST 解析器的已识别动态标签列表中缺少 `selectKey`，导致它被当作原始 SQL 文本处理并被 SQL 格式化器破坏
+  - **根本原因 2**：解析器会在遇到任何 `</` 闭合标签序列时停止解析，而不仅仅是已知标签——因此 `</selectKey>` 导致解析器停止，丢失了所有后续内容
+  - **解决方案**：将 `selectKey` 添加到已识别的动态标签列表中，并使解析器仅在已知动态标签的闭合标签处停止
+  - 添加了 6 个新的单元测试，用于 `<selectKey>` 标签保留和未知闭合标签健壮性
+
+### 技术细节
+
+- **DYNAMIC_TAGS 更新**：在 `MybatisSqlFormatter.ts` 的格式化器已识别标签列表中添加了 `selectkey`
+- **解析器健壮性**：更新了 CST 解析器中的 `parseNodes()` 和 `parseText()`，在停止前先检查闭合标签名称——未知的闭合标签现在被当作文本消费，而不是导致提前终止
+- **大小写敏感**：标签匹配使用 `.toLowerCase()` 比较，因此 `<selectKey>`、`<SelectKey>`、`<SELECTKEY>` 都能正确识别，同时在输出中保留原始大小写
+
 ## [0.3.13] - 2026-02-03
 
 ### 修复

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mybatis-boost",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "publisher": "young1lin",
   "license": "MIT",
   "packageManager": "pnpm@10.19.0",

--- a/src/formatter/MybatisSqlFormatter.ts
+++ b/src/formatter/MybatisSqlFormatter.ts
@@ -95,7 +95,22 @@ class MybatisSqlParser {
 
             if (char === '<') {
                 if (this.peek(1) === '/') {
-                    break; // Closing tag
+                    // Only break if closing tag matches a known dynamic tag.
+                    // This prevents losing content after unknown closing tags
+                    // (e.g., </selectKey> when selectKey was not yet in DYNAMIC_TAGS).
+                    const savedPos = this.position;
+                    this.position += 2;
+                    const closingTagName = this.parseTagName();
+                    this.position = savedPos;
+
+                    if (this.dynamicTags.includes(closingTagName.toLowerCase())) {
+                        break; // Known closing tag - return to parent parseTag()
+                    }
+
+                    // Unknown closing tag - consume as text
+                    const text = this.parseText();
+                    if (text) { nodes.push(text); }
+                    continue;
                 }
 
                 const tag = this.parseTag();
@@ -298,13 +313,27 @@ class MybatisSqlParser {
             const char = this.input[this.position];
 
             if (char === '<') {
-                if (this.peek(1) === '/') { break; } // Closing tag
-                // Check if it's a valid tag
-                const savedPos = this.position;
-                this.position++;
-                const tagName = this.parseTagName();
-                this.position = savedPos;
-                if (this.dynamicTags.includes(tagName.toLowerCase())) { break; };
+                if (this.peek(1) === '/') {
+                    // Only break for closing tags of known dynamic tags.
+                    // Unknown closing tags (e.g., custom XML tags) are consumed as text.
+                    const savedPos = this.position;
+                    this.position += 2;
+                    const closingTagName = this.parseTagName();
+                    this.position = savedPos;
+
+                    if (this.dynamicTags.includes(closingTagName.toLowerCase())) {
+                        break; // Known closing tag
+                    }
+                    // Unknown closing tag - consume as text (fall through)
+                } else {
+                    // Check if it's an opening tag of a known dynamic tag
+                    const savedPos = this.position;
+                    this.position++;
+                    const tagName = this.parseTagName();
+                    this.position = savedPos;
+                    if (this.dynamicTags.includes(tagName.toLowerCase())) { break; }
+                    // Unknown opening tag - consume as text (fall through)
+                }
             }
 
             if ((char === '#' || char === '$') && this.peek(1) === '{') {
@@ -315,7 +344,7 @@ class MybatisSqlParser {
             this.position++;
         }
 
-        if (content.length === 0) { return null; };
+        if (content.length === 0) { return null; }
 
         return {
             type: 'sql',
@@ -530,7 +559,8 @@ export class MybatisSqlFormatter {
      */
     private readonly DYNAMIC_TAGS = [
         'if', 'choose', 'when', 'otherwise', 'foreach',
-        'where', 'set', 'trim', 'bind', 'include', 'property'
+        'where', 'set', 'trim', 'bind', 'include', 'property',
+        'selectkey'
     ];
 
     /**

--- a/src/test/unit/MybatisSqlFormatter.test.ts
+++ b/src/test/unit/MybatisSqlFormatter.test.ts
@@ -1159,4 +1159,149 @@ AND status IN <foreach collection="statusList" item="status" open="(" separator=
             assert.ok(hasProperlyIndentedIf, '<if> tags should have proper indentation');
         });
     });
+
+    describe('selectKey Tag Preservation', () => {
+        it('should preserve <selectKey> tag inside INSERT statement', () => {
+            const input = `<selectKey keyProperty="id" order="AFTER" resultType="java.lang.Long">SELECT LAST_INSERT_ID()</selectKey>
+insert into user_account
+<trim prefix="(" suffix=")" suffixOverrides=",">
+<if test="id != null">id,</if>
+<if test="userName != null">user_name,</if>
+<if test="email != null">email,</if>
+</trim>
+<trim prefix="values (" suffix=")" suffixOverrides=",">
+<if test="id != null">#{id,jdbcType=BIGINT},</if>
+<if test="userName != null">#{userName,jdbcType=VARCHAR},</if>
+<if test="email != null">#{email,jdbcType=VARCHAR},</if>
+</trim>`;
+            const result = formatter.format(input);
+
+            // selectKey tag should be preserved intact
+            assert.ok(result.includes('<selectKey'), 'Should preserve <selectKey> opening tag');
+            assert.ok(result.includes('keyProperty="id"'), 'Should preserve keyProperty attribute');
+            assert.ok(result.includes('order="AFTER"'), 'Should preserve order attribute (not uppercased)');
+            assert.ok(result.includes('resultType="java.lang.Long"'), 'Should preserve resultType attribute');
+            assert.ok(result.includes('</selectKey>'), 'Should preserve </selectKey> closing tag');
+            assert.ok(result.includes('LAST_INSERT_ID()'), 'Should preserve SQL inside selectKey');
+
+            // Content after selectKey should NOT be lost
+            assert.ok(result.includes('<trim'), 'Should preserve <trim> tags after selectKey');
+            assert.ok(result.includes('<if test="id != null">'), 'Should preserve <if> tags after selectKey');
+            assert.ok(result.includes('#{id,jdbcType=BIGINT}'), 'Should preserve parameters after selectKey');
+            assert.ok(result.includes('#{userName,jdbcType=VARCHAR}'), 'Should preserve parameters after selectKey');
+
+            // Both trim tags should be present
+            const trimCount = (result.match(/<trim/g) || []).length;
+            assert.strictEqual(trimCount, 2, 'Should have 2 <trim> tags');
+
+            // All if tags should be present
+            const ifCount = (result.match(/<if test=/g) || []).length;
+            assert.strictEqual(ifCount, 6, 'Should have 6 <if> tags');
+        });
+
+        it('should preserve <selectKey> with order="BEFORE"', () => {
+            const input = `<selectKey keyProperty="id" order="BEFORE" resultType="java.lang.String">SELECT REPLACE(UUID(), '-', '')</selectKey>
+insert into sys_config (id, config_key, config_value)
+values (#{id,jdbcType=VARCHAR}, #{configKey,jdbcType=VARCHAR}, #{configValue,jdbcType=VARCHAR})`;
+            const result = formatter.format(input);
+
+            assert.ok(result.includes('<selectKey'), 'Should preserve <selectKey> tag');
+            assert.ok(result.includes('order="BEFORE"'), 'Should preserve order="BEFORE"');
+            assert.ok(result.includes('</selectKey>'), 'Should preserve closing tag');
+            assert.ok(result.includes('UUID()'), 'Should preserve UUID function');
+
+            // SQL after selectKey should be preserved
+            assert.ok(result.includes('INSERT INTO') || result.includes('insert into'), 'Should preserve INSERT statement');
+            assert.ok(result.includes('#{id,jdbcType=VARCHAR}'), 'Should preserve parameters');
+        });
+
+        it('should properly indent <selectKey> content', () => {
+            const input = `<selectKey keyProperty="id" order="AFTER" resultType="java.lang.Long">
+SELECT LAST_INSERT_ID()
+</selectKey>
+insert into demo_table (name, status) values (#{name}, #{status})`;
+            const result = formatter.format(input);
+
+            // selectKey should be on its own line with proper indentation
+            const lines = result.split('\n');
+            const selectKeyLine = lines.find(l => l.includes('<selectKey'));
+            const closingLine = lines.find(l => l.includes('</selectKey>'));
+
+            assert.ok(selectKeyLine, 'Should have <selectKey> line');
+            assert.ok(closingLine, 'Should have </selectKey> line');
+
+            // The SQL inside should exist
+            assert.ok(result.includes('LAST_INSERT_ID()'), 'Should preserve SQL content');
+        });
+
+        it('should handle <selectKey> with many following dynamic tags', () => {
+            const input = `<selectKey keyProperty="id" order="AFTER" resultType="java.lang.Long">SELECT LAST_INSERT_ID()</selectKey>
+insert into product
+<trim prefix="(" suffix=")" suffixOverrides=",">
+<if test="productName != null">product_name,</if>
+<if test="price != null">price,</if>
+<if test="category != null">category,</if>
+<if test="stock != null">stock,</if>
+<if test="createTime != null">create_time,</if>
+<if test="updateTime != null">update_time,</if>
+</trim>
+<trim prefix="values (" suffix=")" suffixOverrides=",">
+<if test="productName != null">#{productName,jdbcType=VARCHAR},</if>
+<if test="price != null">#{price,jdbcType=DECIMAL},</if>
+<if test="category != null">#{category,jdbcType=VARCHAR},</if>
+<if test="stock != null">#{stock,jdbcType=INTEGER},</if>
+<if test="createTime != null">#{createTime,jdbcType=TIMESTAMP},</if>
+<if test="updateTime != null">#{updateTime,jdbcType=TIMESTAMP},</if>
+</trim>`;
+            const result = formatter.format(input);
+
+            // selectKey should be preserved
+            assert.ok(result.includes('<selectKey'), 'Should preserve selectKey');
+            assert.ok(result.includes('</selectKey>'), 'Should preserve closing selectKey');
+
+            // ALL content after selectKey must be preserved
+            assert.ok(result.includes('#{productName,jdbcType=VARCHAR}'), 'Should preserve productName param');
+            assert.ok(result.includes('#{price,jdbcType=DECIMAL}'), 'Should preserve price param');
+            assert.ok(result.includes('#{createTime,jdbcType=TIMESTAMP}'), 'Should preserve createTime param');
+            assert.ok(result.includes('#{updateTime,jdbcType=TIMESTAMP}'), 'Should preserve updateTime param');
+
+            // Count all if tags - none should be lost
+            const ifCount = (result.match(/<if test=/g) || []).length;
+            assert.strictEqual(ifCount, 12, 'All 12 <if> tags should be preserved');
+
+            // Count closing if tags
+            const closeIfCount = (result.match(/<\/if>/g) || []).length;
+            assert.strictEqual(closeIfCount, 12, 'All 12 </if> tags should be preserved');
+        });
+    });
+
+    describe('Unknown Closing Tag Robustness', () => {
+        it('should not lose content after unknown closing tags', () => {
+            // Simulate an unknown XML tag that is not in DYNAMIC_TAGS
+            // The parser should consume it as text and continue parsing
+            const input = `SELECT * FROM users
+<customTag>some content</customTag>
+<where><if test="status != null">AND status = #{status}</if></where>`;
+            const result = formatter.format(input);
+
+            // Content after unknown closing tag should NOT be lost
+            assert.ok(result.includes('<where>'), 'Should preserve <where> after unknown tag');
+            assert.ok(result.includes('<if test="status != null">'), 'Should preserve <if> after unknown tag');
+            assert.ok(result.includes('#{status}'), 'Should preserve parameter after unknown tag');
+            assert.ok(result.includes('</where>'), 'Should preserve </where>');
+        });
+
+        it('should handle multiple unknown tags without losing subsequent content', () => {
+            const input = `<unknownA>content A</unknownA>
+<unknownB>content B</unknownB>
+SELECT id FROM demo_table
+<if test="name != null">WHERE name = #{name}</if>`;
+            const result = formatter.format(input);
+
+            // Known tags after unknown tags should be preserved
+            assert.ok(result.includes('<if test="name != null">'), 'Should preserve <if> tag');
+            assert.ok(result.includes('#{name}'), 'Should preserve parameter');
+            assert.ok(result.includes('</if>'), 'Should preserve </if>');
+        });
+    });
 });


### PR DESCRIPTION
## Summary
Fixed a critical bug in the MyBatis XML formatter where `<selectKey>` tags inside `<insert>` statements were being mangled and all content after them was lost. The root cause was that `selectKey` was not recognized as a dynamic tag, and the parser would break on any closing tag sequence without validating it was a known tag.

## Key Changes

- **Added `selectkey` to DYNAMIC_TAGS list** in `MybatisSqlFormatter.ts` so the formatter recognizes it as a valid MyBatis dynamic tag
- **Enhanced parser robustness** by making `parseNodes()` and `parseText()` peek ahead at closing tag names before breaking. Unknown closing tags are now consumed as text instead of causing early termination
- **Improved tag matching** to use case-insensitive comparison (`.toLowerCase()`) while preserving original case in output, so `<selectKey>`, `<SelectKey>`, and `<SELECTKEY>` all work correctly
- **Added 6 comprehensive unit tests** covering:
  - `<selectKey>` preservation with AFTER/BEFORE order attributes
  - Content preservation after `<selectKey>` tags
  - Proper indentation of `<selectKey>` blocks
  - Complex scenarios with multiple dynamic tags following `<selectKey>`
  - Unknown closing tag robustness to prevent content loss

## Technical Details

The parser now validates closing tags before breaking the parse loop. When encountering `</`, it:
1. Peeks ahead to extract the tag name
2. Checks if it's in the DYNAMIC_TAGS list
3. Only breaks if it's a known tag; otherwise consumes it as text and continues

This prevents the parser from losing content when encountering unknown XML tags while still properly handling all recognized MyBatis dynamic tags.

https://claude.ai/code/session_01ED9CTsJ8kYpNHYsxNAiwKo