### PR TITLE
Resolve pre-activation timeout by switching to lazy, per-project mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,7 +344,7 @@
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
     "test": "pnpm run test:unit && pnpm run test:integration",
-    "test:unit": "pnpm exec mocha src/test/unit/**/*.test.ts",
+    "test:unit": "pnpm exec mocha 'src/test/unit/**/*.test.ts'",
     "test:integration": "vscode-test",
     "release": "node -e \"const v = require('./package.json').version; require('child_process').execSync(`git tag -a v${v} -m \\\"Release ${v}\\\" && git push && git push --tags`, {stdio: 'inherit'})\""
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "activationEvents": [
     "onLanguage:java",
     "onLanguage:xml",
+    "onDebugAdapterProtocolTracker:java",
     "workspaceContains:**/pom.xml",
     "workspaceContains:**/build.gradle",
     "workspaceContains:**/build.gradle.kts"

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
     "sql"
   ],
   "activationEvents": [
+    "onLanguage:java",
+    "onLanguage:xml",
     "workspaceContains:**/pom.xml",
     "workspaceContains:**/build.gradle",
-    "workspaceContains:**/*.java"
+    "workspaceContains:**/build.gradle.kts"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import {
 import { XmlSqlHoverProvider, JavaSqlHoverProvider } from './hover';
 import { MybatisBindingDecorator, DynamicSqlHighlighter } from './decorator';
 import { findProjectFileInParents } from './utils/projectDetector';
+import { WORKSPACE_EXCLUDE_PATTERN } from './utils/fileUtils';
 import { GeneratorViewProvider } from './webview/GeneratorViewProvider';
 import { MybatisLogViewProvider } from './webview/MybatisLogViewProvider';
 import { MCPManager } from './mcp/MCPManager';
@@ -302,7 +303,7 @@ async function isJavaProject(): Promise<boolean> {
     console.log('[MyBatis Boost] No project files found, checking for Java files...');
     const javaFiles = await vscode.workspace.findFiles(
         '**/*.java',
-        '**/{ node_modules,target,.git,build,dist,out,bin}/**',
+        WORKSPACE_EXCLUDE_PATTERN,
         1  // Only need to find 1 file to confirm it's a Java project
     );
 

--- a/src/navigator/core/FileMapper.ts
+++ b/src/navigator/core/FileMapper.ts
@@ -8,6 +8,8 @@ import { extractJavaNamespace, isMyBatisMapper } from '../parsers/javaParser';
 import { extractXmlNamespace } from '../parsers/xmlParser';
 import { getFileModTime, normalizePath, WORKSPACE_EXCLUDE_PATTERN } from '../../utils/fileUtils';
 import { LRUCache } from '../../utils/LRUCache';
+import { findProjectFileInParents } from '../../utils/projectDetector';
+import { findJavaClassFile } from '../../utils/navigationUtils';
 
 /**
  * FileMapper manages mappings between Java mapper interfaces and XML files
@@ -17,49 +19,35 @@ export class FileMapper {
     private context: vscode.ExtensionContext;
     private watchers: vscode.FileSystemWatcher[] = [];
 
+    /**
+     * Per-project XML namespace index: projectRoot -> (namespace -> xmlPaths).
+     * Built lazily, only when a mapper cannot be resolved via quick paths, and
+     * cached so repeated lookups within the same project never rescan.
+     */
+    private xmlIndexByProject = new Map<string, Map<string, string[]>>();
+    /** In-flight index builds, to de-duplicate concurrent lookups in the same project. */
+    private xmlIndexPromises = new Map<string, Promise<Map<string, string[]>>>();
+
     constructor(context: vscode.ExtensionContext, cacheSize: number = 1000) {
         this.context = context;
         this.cache = new LRUCache(cacheSize);
     }
 
     /**
-     * Initialize the mapper by scanning workspace
+     * Initialize the mapper.
+     *
+     * NOTE: This intentionally does NOT scan the workspace. With many Spring Boot
+     * projects open, an upfront `findFiles('**\/*.java')` + per-mapper XML scan made
+     * activation take up to ~120s (see issue #46). Mappings are now resolved on demand
+     * (per file, per project) and cached. Activation only wires up the file watchers.
      */
     async initialize(): Promise<void> {
-        console.log('[MyBatis Boost] Initializing FileMapper...');
+        console.log('[MyBatis Boost] Initializing FileMapper (lazy, per-project)...');
 
-        // Setup file watchers
+        // Setup file watchers only - no upfront workspace scan.
         this.setupFileWatchers();
 
-        // Perform initial scan
-        await this.scanWorkspace();
-
-        console.log('[MyBatis Boost] FileMapper initialized');
-    }
-
-    /**
-     * Scan workspace for Java mapper files
-     */
-    private async scanWorkspace(): Promise<void> {
-        const javaFiles = await vscode.workspace.findFiles(
-            '**/*.java',
-            WORKSPACE_EXCLUDE_PATTERN
-        );
-
-        console.log(`[MyBatis Boost] Found ${javaFiles.length} Java files, checking for mappers...`);
-
-        let mapperCount = 0;
-        for (const javaUri of javaFiles) {
-            const javaPath = javaUri.fsPath;
-
-            // Check if it's a MyBatis mapper
-            if (await isMyBatisMapper(javaPath)) {
-                await this.buildMappingForJavaFile(javaPath);
-                mapperCount++;
-            }
-        }
-
-        console.log(`[MyBatis Boost] Built mappings for ${mapperCount} mapper interfaces`);
+        console.log('[MyBatis Boost] FileMapper initialized (mappings resolved on demand)');
     }
 
     /**
@@ -118,28 +106,119 @@ export class FileMapper {
             }
         }
 
-        // Priority 1: Search all XML files, prefer same module (longest common prefix)
+        // Priority 1: Look up the namespace in the lazy, per-project XML index.
+        // The index is built (and cached) only once per project, so this avoids the
+        // O(mappers x xmlFiles) full-workspace rescan that previously ran per mapper.
+        const projectRoot = this.getProjectRoot(javaPath);
+        const index = await this.getProjectXmlIndex(projectRoot);
+        const candidates = index.get(namespace);
+        if (!candidates || candidates.length === 0) {
+            return null;
+        }
+
+        // Prefer the candidate in the same module (longest common path prefix).
+        const javaPathNormalized = javaPath.replace(/\\/g, '/');
+        return this.pickBestByPrefix(javaPathNormalized, candidates);
+    }
+
+    /**
+     * Resolve the project/module root that owns a file by walking up to the nearest
+     * build file (pom.xml / build.gradle / build.gradle.kts). Falls back to the
+     * enclosing workspace folder, then the first workspace folder.
+     */
+    private getProjectRoot(filePath: string): string {
+        const projectFile = findProjectFileInParents(path.dirname(filePath));
+        if (projectFile) {
+            return path.dirname(projectFile);
+        }
+
+        const folder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
+        if (folder) {
+            return folder.uri.fsPath;
+        }
+
+        return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? path.dirname(filePath);
+    }
+
+    /**
+     * Get (and lazily build + cache) the namespace -> xmlPaths index for a project.
+     * Concurrent callers share a single in-flight build.
+     */
+    private async getProjectXmlIndex(projectRoot: string): Promise<Map<string, string[]>> {
+        const cached = this.xmlIndexByProject.get(projectRoot);
+        if (cached) {
+            return cached;
+        }
+
+        const inflight = this.xmlIndexPromises.get(projectRoot);
+        if (inflight) {
+            return inflight;
+        }
+
+        const promise = this.buildProjectXmlIndex(projectRoot);
+        this.xmlIndexPromises.set(projectRoot, promise);
+        try {
+            const index = await promise;
+            this.xmlIndexByProject.set(projectRoot, index);
+            return index;
+        } finally {
+            this.xmlIndexPromises.delete(projectRoot);
+        }
+    }
+
+    /**
+     * Scan a single project's XML files once and group their paths by namespace.
+     * Scoped to the project root via RelativePattern so other projects are untouched.
+     */
+    private async buildProjectXmlIndex(projectRoot: string): Promise<Map<string, string[]>> {
+        const index = new Map<string, string[]>();
         const xmlFiles = await vscode.workspace.findFiles(
-            '**/*.xml',
+            new vscode.RelativePattern(projectRoot, '**/*.xml'),
             WORKSPACE_EXCLUDE_PATTERN
         );
 
-        const javaPathNormalized = javaPath.replace(/\\/g, '/');
-        let bestXmlPath: string | null = null;
-        let bestPrefixLen = -1;
-
         for (const xmlUri of xmlFiles) {
             const xmlPath = xmlUri.fsPath;
-            if (await this.verifyXmlFile(xmlPath, namespace)) {
-                const prefixLen = this.getCommonPrefixLength(javaPathNormalized, xmlPath);
-                if (prefixLen > bestPrefixLen) {
-                    bestPrefixLen = prefixLen;
-                    bestXmlPath = xmlPath;
-                }
+            const xmlNamespace = await extractXmlNamespace(xmlPath);
+            if (!xmlNamespace) {
+                continue;
+            }
+            const existing = index.get(xmlNamespace);
+            if (existing) {
+                existing.push(xmlPath);
+            } else {
+                index.set(xmlNamespace, [xmlPath]);
             }
         }
 
-        return bestXmlPath;
+        console.log(`[MyBatis Boost] Indexed ${xmlFiles.length} XML files in project ${projectRoot}`);
+        return index;
+    }
+
+    /**
+     * Drop the cached XML index (and any in-flight build) for the project owning a file.
+     */
+    private invalidateXmlIndexForFile(filePath: string): void {
+        const projectRoot = this.getProjectRoot(filePath);
+        this.xmlIndexByProject.delete(projectRoot);
+        this.xmlIndexPromises.delete(projectRoot);
+    }
+
+    /**
+     * From a list of candidate paths, pick the one sharing the longest directory
+     * prefix with the reference path (i.e. the same module).
+     */
+    private pickBestByPrefix(referencePath: string, candidates: string[]): string | null {
+        let best: string | null = null;
+        let bestPrefixLen = -1;
+        for (const candidate of candidates) {
+            const prefixLen = this.getCommonPrefixLength(referencePath, candidate);
+            if (prefixLen > bestPrefixLen) {
+                bestPrefixLen = prefixLen;
+                best = candidate;
+            }
+        }
+        return best;
     }
 
     /**
@@ -247,33 +326,20 @@ export class FileMapper {
             return null;
         }
 
-        // Search Java files for matching namespace, prefer same module
-        const javaFiles = await vscode.workspace.findFiles(
-            '**/*.java',
-            WORKSPACE_EXCLUDE_PATTERN
-        );
-
-        const xmlPathNormalized = xmlPath.replace(/\\/g, '/');
-        let bestJavaPath: string | null = null;
-        let bestPrefixLen = -1;
-
-        for (const javaUri of javaFiles) {
-            const javaPath = javaUri.fsPath;
-            const javaNamespace = await extractJavaNamespace(javaPath);
-
-            if (javaNamespace === namespace) {
-                const prefixLen = this.getCommonPrefixLength(xmlPathNormalized, javaPath);
-                if (prefixLen > bestPrefixLen) {
-                    bestPrefixLen = prefixLen;
-                    bestJavaPath = javaPath;
-                }
-            }
+        // The namespace IS the fully-qualified Java interface name, so resolve it
+        // directly via a bounded package-path search, scoped to the same project
+        // first and falling back to the workspace. No full '**/*.java' scan.
+        const projectRoot = this.getProjectRoot(xmlPath);
+        let javaUri = await findJavaClassFile(namespace, projectRoot);
+        if (!javaUri) {
+            javaUri = await findJavaClassFile(namespace);
         }
 
-        if (bestJavaPath) {
-            await this.buildMappingForJavaFile(bestJavaPath);
+        if (javaUri) {
+            await this.buildMappingForJavaFile(javaUri.fsPath);
+            return javaUri.fsPath;
         }
-        return bestJavaPath;
+        return null;
     }
 
     /**
@@ -314,36 +380,25 @@ export class FileMapper {
      */
     private async handleXmlFileCreate(filePath: string): Promise<void> {
         try {
+            // A new XML file must be picked up by the project's namespace index.
+            this.invalidateXmlIndexForFile(filePath);
+
             const namespace = await extractXmlNamespace(filePath);
             if (!namespace) {
                 return;
             }
 
-            // Search for corresponding Java mapper, prefer same module
-            const javaFiles = await vscode.workspace.findFiles(
-                '**/*.java',
-                WORKSPACE_EXCLUDE_PATTERN
-            );
-
-            const xmlPathNormalized = filePath.replace(/\\/g, '/');
-            let bestJavaPath: string | null = null;
-            let bestPrefixLen = -1;
-
-            for (const javaUri of javaFiles) {
-                const javaPath = javaUri.fsPath;
-                const javaNamespace = await extractJavaNamespace(javaPath);
-                if (javaNamespace === namespace) {
-                    const prefixLen = this.getCommonPrefixLength(xmlPathNormalized, javaPath);
-                    if (prefixLen > bestPrefixLen) {
-                        bestPrefixLen = prefixLen;
-                        bestJavaPath = javaPath;
-                    }
-                }
+            // The namespace is the Java interface FQN; resolve it with a bounded,
+            // project-scoped search instead of scanning every '**/*.java' file.
+            const projectRoot = this.getProjectRoot(filePath);
+            let javaUri = await findJavaClassFile(namespace, projectRoot);
+            if (!javaUri) {
+                javaUri = await findJavaClassFile(namespace);
             }
 
-            if (bestJavaPath) {
-                await this.buildMappingForJavaFile(bestJavaPath);
-                console.log(`[MyBatis Boost] New XML mapped to ${bestJavaPath}`);
+            if (javaUri) {
+                await this.buildMappingForJavaFile(javaUri.fsPath);
+                console.log(`[MyBatis Boost] New XML mapped to ${javaUri.fsPath}`);
             }
         } catch (error) {
             console.error(`[MyBatis Boost] Error handling new XML file:`, error);
@@ -377,6 +432,8 @@ export class FileMapper {
         if (filePath.endsWith('.java')) {
             this.buildMappingForJavaFile(filePath);
         } else if (filePath.endsWith('.xml')) {
+            // An XML edit may change its namespace, so drop the project's cached index.
+            this.invalidateXmlIndexForFile(filePath);
             // For XML file changes, we need to find the corresponding Java file and rebuild
             if (mapping && mapping.javaPath) {
                 this.buildMappingForJavaFile(mapping.javaPath);
@@ -406,6 +463,11 @@ export class FileMapper {
                 this.cache.delete(normalizePath(mapping.javaPath));
             }
         }
+
+        // A deleted XML file must be dropped from the project's namespace index.
+        if (filePath.endsWith('.xml')) {
+            this.invalidateXmlIndexForFile(filePath);
+        }
     }
 
     /**
@@ -424,10 +486,13 @@ export class FileMapper {
     }
 
     /**
-     * Clear all cached mappings
+     * Clear all cached mappings (and the per-project XML indexes), forcing a fresh
+     * lazy rebuild on the next lookup.
      */
     clearCache(): void {
         this.cache.clear();
+        this.xmlIndexByProject.clear();
+        this.xmlIndexPromises.clear();
     }
 
     /**
@@ -436,5 +501,7 @@ export class FileMapper {
     dispose(): void {
         this.watchers.forEach(watcher => watcher.dispose());
         this.cache.clear();
+        this.xmlIndexByProject.clear();
+        this.xmlIndexPromises.clear();
     }
 }

--- a/src/navigator/core/FileMapper.ts
+++ b/src/navigator/core/FileMapper.ts
@@ -58,6 +58,12 @@ export class FileMapper {
     async initialize(): Promise<void> {
         console.log('[MyBatis Boost] Initializing FileMapper (lazy, per-project)...');
 
+        // Idempotent: dispose any existing watchers before wiring up new ones, so
+        // re-initialization (e.g. from the Refresh Mappings / Clear Cache commands)
+        // does not leak watchers or double-fire change handlers.
+        this.watchers.forEach(watcher => watcher.dispose());
+        this.watchers.length = 0;
+
         // Setup file watchers only - no upfront workspace scan.
         this.setupFileWatchers();
 

--- a/src/navigator/core/FileMapper.ts
+++ b/src/navigator/core/FileMapper.ts
@@ -11,6 +11,12 @@ import { LRUCache } from '../../utils/LRUCache';
 import { findProjectFileInParents } from '../../utils/projectDetector';
 import { findJavaClassFile } from '../../utils/navigationUtils';
 
+/** A project's XML namespace index plus the time it was built (for TTL self-healing). */
+interface ProjectXmlIndex {
+    builtAt: number;
+    byNamespace: Map<string, string[]>;
+}
+
 /**
  * FileMapper manages mappings between Java mapper interfaces and XML files
  */
@@ -24,9 +30,17 @@ export class FileMapper {
      * Built lazily, only when a mapper cannot be resolved via quick paths, and
      * cached so repeated lookups within the same project never rescan.
      */
-    private xmlIndexByProject = new Map<string, Map<string, string[]>>();
+    private xmlIndexByProject = new Map<string, ProjectXmlIndex>();
     /** In-flight index builds, to de-duplicate concurrent lookups in the same project. */
-    private xmlIndexPromises = new Map<string, Promise<Map<string, string[]>>>();
+    private xmlIndexPromises = new Map<string, Promise<ProjectXmlIndex>>();
+    /**
+     * Backstop TTL for a project's XML index. File watchers invalidate the index
+     * instantly on edits, but OS watchers can miss events (network/virtual drives,
+     * containers, or bulk out-of-editor edits via CLI tools like Claude Code / Codex).
+     * The TTL guarantees the index self-heals within this window even when no watcher
+     * event arrives, so the cache is never effectively "permanent".
+     */
+    private static readonly XML_INDEX_TTL_MS = 30_000;
 
     constructor(context: vscode.ExtensionContext, cacheSize: number = 1000) {
         this.context = context;
@@ -107,18 +121,31 @@ export class FileMapper {
         }
 
         // Priority 1: Look up the namespace in the lazy, per-project XML index.
-        // The index is built (and cached) only once per project, so this avoids the
-        // O(mappers x xmlFiles) full-workspace rescan that previously ran per mapper.
+        // The index is built once per project and reused (with a TTL backstop), so
+        // this avoids the O(mappers x xmlFiles) full-workspace rescan that previously
+        // ran per mapper.
         const projectRoot = this.getProjectRoot(javaPath);
         const index = await this.getProjectXmlIndex(projectRoot);
-        const candidates = index.get(namespace);
+        const candidates = index.byNamespace.get(namespace);
         if (!candidates || candidates.length === 0) {
             return null;
         }
 
-        // Prefer the candidate in the same module (longest common path prefix).
+        // Prefer same-module candidates (longest common prefix), but re-verify the
+        // chosen file still exists and matches the namespace before returning it: the
+        // cached index can lag a moved/deleted/renamed file if its watcher event was
+        // missed (e.g. bulk CLI edits). Verification keeps results correct regardless.
         const javaPathNormalized = javaPath.replace(/\\/g, '/');
-        return this.pickBestByPrefix(javaPathNormalized, candidates);
+        const ordered = [...candidates].sort(
+            (a, b) => this.getCommonPrefixLength(javaPathNormalized, b)
+                - this.getCommonPrefixLength(javaPathNormalized, a)
+        );
+        for (const candidate of ordered) {
+            if (await this.verifyXmlFile(candidate, namespace)) {
+                return candidate;
+            }
+        }
+        return null;
     }
 
     /**
@@ -144,10 +171,14 @@ export class FileMapper {
      * Get (and lazily build + cache) the namespace -> xmlPaths index for a project.
      * Concurrent callers share a single in-flight build.
      */
-    private async getProjectXmlIndex(projectRoot: string): Promise<Map<string, string[]>> {
+    private async getProjectXmlIndex(projectRoot: string): Promise<ProjectXmlIndex> {
         const cached = this.xmlIndexByProject.get(projectRoot);
-        if (cached) {
+        if (cached && Date.now() - cached.builtAt < FileMapper.XML_INDEX_TTL_MS) {
             return cached;
+        }
+        // Expired (or absent): drop the stale snapshot and rebuild below.
+        if (cached) {
+            this.xmlIndexByProject.delete(projectRoot);
         }
 
         const inflight = this.xmlIndexPromises.get(projectRoot);
@@ -170,8 +201,8 @@ export class FileMapper {
      * Scan a single project's XML files once and group their paths by namespace.
      * Scoped to the project root via RelativePattern so other projects are untouched.
      */
-    private async buildProjectXmlIndex(projectRoot: string): Promise<Map<string, string[]>> {
-        const index = new Map<string, string[]>();
+    private async buildProjectXmlIndex(projectRoot: string): Promise<ProjectXmlIndex> {
+        const byNamespace = new Map<string, string[]>();
         const xmlFiles = await vscode.workspace.findFiles(
             new vscode.RelativePattern(projectRoot, '**/*.xml'),
             WORKSPACE_EXCLUDE_PATTERN
@@ -183,16 +214,16 @@ export class FileMapper {
             if (!xmlNamespace) {
                 continue;
             }
-            const existing = index.get(xmlNamespace);
+            const existing = byNamespace.get(xmlNamespace);
             if (existing) {
                 existing.push(xmlPath);
             } else {
-                index.set(xmlNamespace, [xmlPath]);
+                byNamespace.set(xmlNamespace, [xmlPath]);
             }
         }
 
         console.log(`[MyBatis Boost] Indexed ${xmlFiles.length} XML files in project ${projectRoot}`);
-        return index;
+        return { builtAt: Date.now(), byNamespace };
     }
 
     /**
@@ -202,23 +233,6 @@ export class FileMapper {
         const projectRoot = this.getProjectRoot(filePath);
         this.xmlIndexByProject.delete(projectRoot);
         this.xmlIndexPromises.delete(projectRoot);
-    }
-
-    /**
-     * From a list of candidate paths, pick the one sharing the longest directory
-     * prefix with the reference path (i.e. the same module).
-     */
-    private pickBestByPrefix(referencePath: string, candidates: string[]): string | null {
-        let best: string | null = null;
-        let bestPrefixLen = -1;
-        for (const candidate of candidates) {
-            const prefixLen = this.getCommonPrefixLength(referencePath, candidate);
-            if (prefixLen > bestPrefixLen) {
-                bestPrefixLen = prefixLen;
-                best = candidate;
-            }
-        }
-        return best;
     }
 
     /**

--- a/src/navigator/core/FileMapper.ts
+++ b/src/navigator/core/FileMapper.ts
@@ -8,7 +8,11 @@ import { extractJavaNamespace, isMyBatisMapper } from '../parsers/javaParser';
 import { extractXmlNamespace } from '../parsers/xmlParser';
 import { getFileModTime, normalizePath, WORKSPACE_EXCLUDE_PATTERN } from '../../utils/fileUtils';
 import { LRUCache } from '../../utils/LRUCache';
-import { findProjectFileInParents } from '../../utils/projectDetector';
+import {
+    findProjectFileInParents,
+    findOutermostProjectFileInParents,
+    isPathInside
+} from '../../utils/projectDetector';
 import { findJavaClassFile } from '../../utils/navigationUtils';
 
 /** A project's XML namespace index plus the time it was built (for TTL self-healing). */
@@ -155,22 +159,40 @@ export class FileMapper {
     }
 
     /**
-     * Resolve the project/module root that owns a file by walking up to the nearest
-     * build file (pom.xml / build.gradle / build.gradle.kts). Falls back to the
-     * enclosing workspace folder, then the first workspace folder.
+     * Resolve the project root that owns a file.
+     *
+     * Uses the OUTERMOST build file (pom.xml / build.gradle / build.gradle.kts)
+     * between the file and its workspace folder — i.e. the aggregate root of a
+     * multi-module project — so mapper XML living in a sibling module of the same
+     * project is still visible to the index (the pre-#46 full-workspace scan
+     * supported that layout). The walk never leaves the workspace folder, so
+     * independent services sharing one workspace folder (the issue #46 setup)
+     * each keep their own root and are never scanned together.
+     *
+     * Files outside any workspace folder fall back to the nearest build file,
+     * then the first workspace folder.
      */
     private getProjectRoot(filePath: string): string {
-        const projectFile = findProjectFileInParents(path.dirname(filePath));
+        const startDir = path.dirname(filePath);
+        const folder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
+        const folderPath = folder?.uri.fsPath;
+
+        if (folderPath && isPathInside(startDir, folderPath)) {
+            const outermost = findOutermostProjectFileInParents(startDir, folderPath);
+            if (outermost) {
+                return path.dirname(outermost);
+            }
+            // No build file at all between the file and its workspace folder:
+            // scope to the workspace folder itself.
+            return folderPath;
+        }
+
+        const projectFile = findProjectFileInParents(startDir);
         if (projectFile) {
             return path.dirname(projectFile);
         }
 
-        const folder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
-        if (folder) {
-            return folder.uri.fsPath;
-        }
-
-        return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? path.dirname(filePath);
+        return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? startDir;
     }
 
     /**

--- a/src/test/helpers/vscode-mock.js
+++ b/src/test/helpers/vscode-mock.js
@@ -47,6 +47,23 @@ const vscode = {
         }
     },
 
+    RelativePattern: class RelativePattern {
+        constructor(base, pattern) {
+            // base may be a WorkspaceFolder, a Uri, or a string path
+            if (base && base.uri && base.uri.fsPath) {
+                this.baseUri = base.uri;
+                this.base = base.uri.fsPath;
+            } else if (base && base.fsPath) {
+                this.baseUri = base;
+                this.base = base.fsPath;
+            } else {
+                this.base = String(base);
+                this.baseUri = { fsPath: this.base };
+            }
+            this.pattern = pattern;
+        }
+    },
+
     workspace: {
         workspaceFolders: [
             {
@@ -112,6 +129,19 @@ const vscode = {
         textDocuments: [],
         findFiles: function(include, exclude, maxResults) {
             return Promise.resolve([]);
+        },
+        getWorkspaceFolder: function(uri) {
+            const folders = vscode.workspace.workspaceFolders;
+            return folders && folders.length > 0 ? folders[0] : undefined;
+        },
+        createFileSystemWatcher: function(pattern) {
+            const noop = () => ({ dispose: () => {} });
+            return {
+                onDidCreate: noop,
+                onDidChange: noop,
+                onDidDelete: noop,
+                dispose: () => {}
+            };
         }
     },
 

--- a/src/test/unit/FileMapper.test.ts
+++ b/src/test/unit/FileMapper.test.ts
@@ -224,5 +224,21 @@ describe('FileMapper Unit Tests', () => {
                 'RelativePattern base should be the project root'
             );
         });
+
+        it('rebuilds the index after the TTL so out-of-editor changes self-heal', async () => {
+            // Only fake Date so file-system promises keep working normally.
+            const clock = sandbox.useFakeTimers({ now: Date.now(), toFake: ['Date'] });
+            const findFilesStub = sandbox.stub(vscode.workspace, 'findFiles')
+                .resolves([vscode.Uri.file(fooXml), vscode.Uri.file(barXml)]);
+
+            await fileMapper.getXmlPath(fooJava);
+            assert.strictEqual(findFilesStub.callCount, 1, 'first lookup builds the index');
+
+            // Advance beyond the index TTL (30s); a lookup for a different mapper in the
+            // same project should now rebuild instead of trusting the stale snapshot.
+            clock.tick(31_000);
+            await fileMapper.getXmlPath(barJava);
+            assert.strictEqual(findFilesStub.callCount, 2, 'expired index should be rebuilt');
+        });
     });
 });

--- a/src/test/unit/FileMapper.test.ts
+++ b/src/test/unit/FileMapper.test.ts
@@ -7,6 +7,8 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
 import { FileMapper } from '../../navigator';
 import { createMockContext } from '../helpers/testSetup';
 
@@ -134,6 +136,93 @@ describe('FileMapper Unit Tests', () => {
 
         it('should verify namespace matches when finding XML files', async () => {
             assert.ok(true, 'Namespace verification needs to be tested');
+        });
+    });
+
+    describe('Lazy initialization (issue #46)', () => {
+        it('initialize() must not scan the workspace (no findFiles)', async () => {
+            const findFilesSpy = sandbox.spy(vscode.workspace, 'findFiles');
+            await fileMapper.initialize();
+            assert.strictEqual(
+                findFilesSpy.callCount,
+                0,
+                'initialize() must not trigger any findFiles scan'
+            );
+        });
+    });
+
+    describe('Per-project XML index (issue #46)', () => {
+        const DOCTYPE = '<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" ' +
+            '"http://mybatis.org/dtd/mybatis-3-mapper.dtd">';
+
+        let tmpRoot: string;
+        let projectRoot: string;
+        let fooJava: string;
+        let barJava: string;
+        let fooXml: string;
+        let barXml: string;
+
+        const mapperJava = (name: string) =>
+            `package com.demo;\nimport org.apache.ibatis.annotations.Mapper;\n@Mapper\npublic interface ${name} {}\n`;
+        const mapperXml = (namespace: string) =>
+            `<?xml version="1.0" encoding="UTF-8"?>\n${DOCTYPE}\n<mapper namespace="${namespace}">\n</mapper>\n`;
+
+        beforeEach(() => {
+            tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mb-filemapper-'));
+            projectRoot = path.join(tmpRoot, 'proj');
+            const javaDir = path.join(projectRoot, 'src', 'main', 'java', 'com', 'demo');
+            // XML placed in a custom dir with non-matching filenames so quick paths miss
+            // and the lazy per-project index is exercised.
+            const xmlDir = path.join(projectRoot, 'src', 'main', 'resources', 'custom');
+            fs.mkdirSync(javaDir, { recursive: true });
+            fs.mkdirSync(xmlDir, { recursive: true });
+            fs.writeFileSync(path.join(projectRoot, 'pom.xml'), '<project></project>');
+
+            fooJava = path.join(javaDir, 'FooMapper.java');
+            barJava = path.join(javaDir, 'BarMapper.java');
+            fs.writeFileSync(fooJava, mapperJava('FooMapper'));
+            fs.writeFileSync(barJava, mapperJava('BarMapper'));
+
+            fooXml = path.join(xmlDir, 'Foo.xml');
+            barXml = path.join(xmlDir, 'Bar.xml');
+            fs.writeFileSync(fooXml, mapperXml('com.demo.FooMapper'));
+            fs.writeFileSync(barXml, mapperXml('com.demo.BarMapper'));
+        });
+
+        afterEach(() => {
+            fs.rmSync(tmpRoot, { recursive: true, force: true });
+        });
+
+        it('builds the project XML index once and reuses it across lookups', async () => {
+            const findFilesStub = sandbox.stub(vscode.workspace, 'findFiles')
+                .resolves([vscode.Uri.file(fooXml), vscode.Uri.file(barXml)]);
+
+            const fooResult = await fileMapper.getXmlPath(fooJava);
+            const barResult = await fileMapper.getXmlPath(barJava);
+
+            assert.ok(fooResult && fooResult.endsWith('Foo.xml'), 'FooMapper should resolve to Foo.xml');
+            assert.ok(barResult && barResult.endsWith('Bar.xml'), 'BarMapper should resolve to Bar.xml');
+            assert.strictEqual(
+                findFilesStub.callCount,
+                1,
+                'the per-project index should be built once and reused for the second lookup'
+            );
+        });
+
+        it('scopes the index scan to the project via RelativePattern', async () => {
+            const findFilesStub = sandbox.stub(vscode.workspace, 'findFiles')
+                .resolves([vscode.Uri.file(fooXml), vscode.Uri.file(barXml)]);
+
+            await fileMapper.getXmlPath(fooJava);
+
+            assert.ok(findFilesStub.calledOnce, 'index scan should run exactly once');
+            const include = findFilesStub.firstCall.args[0] as vscode.RelativePattern;
+            assert.ok(include instanceof vscode.RelativePattern, 'include should be a RelativePattern');
+            assert.strictEqual(
+                include.base.replace(/\\/g, '/'),
+                projectRoot.replace(/\\/g, '/'),
+                'RelativePattern base should be the project root'
+            );
         });
     });
 });

--- a/src/test/unit/FileMapper.test.ts
+++ b/src/test/unit/FileMapper.test.ts
@@ -264,4 +264,95 @@ describe('FileMapper Unit Tests', () => {
             assert.strictEqual(findFilesStub.callCount, 2, 'expired index should be rebuilt');
         });
     });
+
+    describe('Cross-module XML resolution (multi-module projects)', () => {
+        const DOCTYPE = '<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" ' +
+            '"http://mybatis.org/dtd/mybatis-3-mapper.dtd">';
+
+        let tmpRoot: string;
+        let savedWorkspaceFolders: typeof vscode.workspace.workspaceFolders;
+
+        const mapperJava = (name: string) =>
+            `package com.demo;\nimport org.apache.ibatis.annotations.Mapper;\n@Mapper\npublic interface ${name} {}\n`;
+        const mapperXml = (namespace: string) =>
+            `<?xml version="1.0" encoding="UTF-8"?>\n${DOCTYPE}\n<mapper namespace="${namespace}">\n</mapper>\n`;
+
+        beforeEach(() => {
+            tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mb-crossmodule-'));
+            // Make the temp root the workspace folder so getProjectRoot's
+            // workspace-bounded aggregate-root walk is exercised (the mocked
+            // getWorkspaceFolder returns workspaceFolders[0]).
+            savedWorkspaceFolders = vscode.workspace.workspaceFolders;
+            (vscode.workspace as any).workspaceFolders = [
+                { uri: { fsPath: tmpRoot }, name: 'tmp', index: 0 }
+            ];
+        });
+
+        afterEach(() => {
+            (vscode.workspace as any).workspaceFolders = savedWorkspaceFolders;
+            fs.rmSync(tmpRoot, { recursive: true, force: true });
+        });
+
+        it('finds XML in a sibling module via the aggregate (parent) build root', async () => {
+            // Multi-module Maven layout with the XML in a different module than the
+            // Java interface — supported by the pre-#46 full scan, must keep working:
+            //   aggregate/pom.xml
+            //   aggregate/module-a/pom.xml + src/main/java/com/demo/FooMapper.java
+            //   aggregate/module-b/pom.xml + src/main/resources/custom/Foo.xml
+            const aggregateRoot = path.join(tmpRoot, 'aggregate');
+            const javaDir = path.join(aggregateRoot, 'module-a', 'src', 'main', 'java', 'com', 'demo');
+            const xmlDir = path.join(aggregateRoot, 'module-b', 'src', 'main', 'resources', 'custom');
+            fs.mkdirSync(javaDir, { recursive: true });
+            fs.mkdirSync(xmlDir, { recursive: true });
+            fs.writeFileSync(path.join(aggregateRoot, 'pom.xml'), '<project></project>');
+            fs.writeFileSync(path.join(aggregateRoot, 'module-a', 'pom.xml'), '<project></project>');
+            fs.writeFileSync(path.join(aggregateRoot, 'module-b', 'pom.xml'), '<project></project>');
+
+            const fooJava = path.join(javaDir, 'FooMapper.java');
+            const fooXml = path.join(xmlDir, 'Foo.xml');
+            fs.writeFileSync(fooJava, mapperJava('FooMapper'));
+            fs.writeFileSync(fooXml, mapperXml('com.demo.FooMapper'));
+
+            const findFilesStub = sandbox.stub(vscode.workspace, 'findFiles')
+                .resolves([vscode.Uri.file(fooXml)]);
+
+            const result = await fileMapper.getXmlPath(fooJava);
+
+            assert.ok(result && result.endsWith('Foo.xml'),
+                'XML in a sibling module should be found via the aggregate root index');
+            const include = findFilesStub.firstCall.args[0] as vscode.RelativePattern;
+            assert.strictEqual(
+                include.base.replace(/\\/g, '/'),
+                aggregateRoot.replace(/\\/g, '/'),
+                'index scan should be rooted at the aggregate (parent pom) root, not the module'
+            );
+        });
+
+        it('keeps independent services isolated when no shared parent build file exists (issue #46 setup)', async () => {
+            // Two standalone services in one workspace folder (no build file at the
+            // workspace root). The index must stay scoped to the owning service —
+            // never widen to the whole workspace, or #46 would regress.
+            const serviceA = path.join(tmpRoot, 'service-a');
+            const javaDir = path.join(serviceA, 'src', 'main', 'java', 'com', 'demo');
+            fs.mkdirSync(javaDir, { recursive: true });
+            fs.mkdirSync(path.join(tmpRoot, 'service-b'), { recursive: true });
+            fs.writeFileSync(path.join(serviceA, 'pom.xml'), '<project></project>');
+            fs.writeFileSync(path.join(tmpRoot, 'service-b', 'pom.xml'), '<project></project>');
+
+            const fooJava = path.join(javaDir, 'FooMapper.java');
+            fs.writeFileSync(fooJava, mapperJava('FooMapper'));
+
+            const findFilesStub = sandbox.stub(vscode.workspace, 'findFiles').resolves([]);
+
+            await fileMapper.getXmlPath(fooJava);
+
+            assert.ok(findFilesStub.calledOnce, 'index scan should run exactly once');
+            const include = findFilesStub.firstCall.args[0] as vscode.RelativePattern;
+            assert.strictEqual(
+                include.base.replace(/\\/g, '/'),
+                serviceA.replace(/\\/g, '/'),
+                'without a shared parent build file the index must stay scoped to the service'
+            );
+        });
+    });
 });

--- a/src/test/unit/FileMapper.test.ts
+++ b/src/test/unit/FileMapper.test.ts
@@ -149,6 +149,29 @@ describe('FileMapper Unit Tests', () => {
                 'initialize() must not trigger any findFiles scan'
             );
         });
+
+        it('is idempotent: re-initializing disposes old watchers instead of leaking them', async () => {
+            const disposed: boolean[] = [];
+            sandbox.stub(vscode.workspace, 'createFileSystemWatcher').callsFake(() => {
+                const idx = disposed.push(false) - 1;
+                return {
+                    onDidCreate: () => ({ dispose: () => {} }),
+                    onDidChange: () => ({ dispose: () => {} }),
+                    onDidDelete: () => ({ dispose: () => {} }),
+                    dispose: () => { disposed[idx] = true; }
+                } as unknown as vscode.FileSystemWatcher;
+            });
+
+            await fileMapper.initialize(); // creates watcher pair #1
+            await fileMapper.initialize(); // must dispose #1 before creating #2
+
+            // The first pair of watchers must have been disposed by the second init.
+            assert.strictEqual(disposed[0], true, 'first java watcher should be disposed');
+            assert.strictEqual(disposed[1], true, 'first xml watcher should be disposed');
+            // And the live set should not grow unbounded across re-inits.
+            const live = disposed.filter(d => !d).length;
+            assert.strictEqual(live, 2, 'exactly one live watcher pair should remain');
+        });
     });
 
     describe('Per-project XML index (issue #46)', () => {

--- a/src/test/unit/activationConfig.test.ts
+++ b/src/test/unit/activationConfig.test.ts
@@ -34,6 +34,13 @@ describe('Activation configuration (issue #46)', () => {
                 'should include workspaceContains:**/build.gradle.kts'
             );
         });
+
+        it('activates on a Java debug session so the SQL log console is ready', () => {
+            assert.ok(
+                events.includes('onDebugAdapterProtocolTracker:java'),
+                'should include onDebugAdapterProtocolTracker:java for the SQL log console'
+            );
+        });
     });
 
     describe('WORKSPACE_EXCLUDE_PATTERN', () => {

--- a/src/test/unit/activationConfig.test.ts
+++ b/src/test/unit/activationConfig.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for activation configuration (issue #46)
+ * Verifies activationEvents avoid the broad workspaceContains:**\/*.java that caused
+ * pre-activation timeouts, and that the workspace exclude pattern is well-formed.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { WORKSPACE_EXCLUDE_PATTERN } from '../../utils/fileUtils';
+
+describe('Activation configuration (issue #46)', () => {
+    const pkg = JSON.parse(
+        fs.readFileSync(path.join(__dirname, '..', '..', '..', 'package.json'), 'utf-8')
+    );
+    const events: string[] = pkg.activationEvents || [];
+
+    describe('package.json activationEvents', () => {
+        it('does not use the broad workspaceContains:**/*.java (caused pre-activation timeout)', () => {
+            assert.ok(
+                !events.includes('workspaceContains:**/*.java'),
+                'workspaceContains:**/*.java must be removed to avoid the file-search timeout'
+            );
+        });
+
+        it('activates lazily on Java and XML languages', () => {
+            assert.ok(events.includes('onLanguage:java'), 'should include onLanguage:java');
+            assert.ok(events.includes('onLanguage:xml'), 'should include onLanguage:xml');
+        });
+
+        it('includes a build.gradle.kts workspace trigger', () => {
+            assert.ok(
+                events.includes('workspaceContains:**/build.gradle.kts'),
+                'should include workspaceContains:**/build.gradle.kts'
+            );
+        });
+    });
+
+    describe('WORKSPACE_EXCLUDE_PATTERN', () => {
+        it('has no leading space after the opening brace', () => {
+            assert.ok(
+                !WORKSPACE_EXCLUDE_PATTERN.includes('{ '),
+                `pattern must not contain "{ " (breaks the first exclusion): ${WORKSPACE_EXCLUDE_PATTERN}`
+            );
+        });
+
+        it('excludes node_modules as the first brace alternative', () => {
+            assert.ok(
+                WORKSPACE_EXCLUDE_PATTERN.includes('{node_modules,'),
+                `node_modules must be excluded: ${WORKSPACE_EXCLUDE_PATTERN}`
+            );
+        });
+    });
+});

--- a/src/test/unit/projectDetector.test.ts
+++ b/src/test/unit/projectDetector.test.ts
@@ -5,7 +5,13 @@
 
 import * as assert from 'assert';
 import * as path from 'path';
-import { findProjectFileInParents, hasProjectFiles, FileExistsFn } from '../../utils/projectDetector';
+import {
+    findProjectFileInParents,
+    findOutermostProjectFileInParents,
+    hasProjectFiles,
+    isPathInside,
+    FileExistsFn
+} from '../../utils/projectDetector';
 
 describe('projectDetector Unit Tests', () => {
     // Helper function to create a mock file existence checker
@@ -128,6 +134,80 @@ describe('projectDetector Unit Tests', () => {
 
             const result = findProjectFileInParents(testPath, 10, mockFileExists);
             assert.strictEqual(result, pomPath);
+        });
+    });
+
+    describe('findOutermostProjectFileInParents', () => {
+        it('returns the aggregate root build file, not the nearest module build file', () => {
+            // Multi-module layout: workspace/project/pom.xml (parent) + module pom
+            const startPath = '/ws/project/module-a/src/main/java/com/demo';
+            const modulePom = path.join('/ws/project/module-a', 'pom.xml');
+            const parentPom = path.join('/ws/project', 'pom.xml');
+            const mockFileExists = createMockFileExists(new Set([modulePom, parentPom]));
+
+            const result = findOutermostProjectFileInParents(startPath, '/ws', mockFileExists);
+            assert.strictEqual(result, parentPom, 'should pick the outermost (aggregate) pom');
+        });
+
+        it('returns the nearest build file when it is the only one below stopDir', () => {
+            const startPath = '/ws/service-a/src/main/java';
+            const servicePom = path.join('/ws/service-a', 'pom.xml');
+            const mockFileExists = createMockFileExists(new Set([servicePom]));
+
+            const result = findOutermostProjectFileInParents(startPath, '/ws', mockFileExists);
+            assert.strictEqual(result, servicePom);
+        });
+
+        it('never walks above stopDir even if a build file exists there', () => {
+            // A stray build file above the workspace folder must be ignored.
+            const startPath = '/home/user/ws/service-a/src';
+            const servicePom = path.join('/home/user/ws/service-a', 'pom.xml');
+            const strayGradle = path.join('/home/user', 'build.gradle');
+            const mockFileExists = createMockFileExists(new Set([servicePom, strayGradle]));
+
+            const result = findOutermostProjectFileInParents(
+                startPath, '/home/user/ws', mockFileExists
+            );
+            assert.strictEqual(result, servicePom, 'stray ancestor build file must be ignored');
+        });
+
+        it('includes a build file directly in stopDir itself', () => {
+            const startPath = '/ws/module/src';
+            const modulePom = path.join('/ws/module', 'pom.xml');
+            const rootGradle = path.join('/ws', 'build.gradle');
+            const mockFileExists = createMockFileExists(new Set([modulePom, rootGradle]));
+
+            const result = findOutermostProjectFileInParents(startPath, '/ws', mockFileExists);
+            assert.strictEqual(result, rootGradle, 'stopDir itself is part of the walk');
+        });
+
+        it('returns null when no build file exists between startPath and stopDir', () => {
+            const mockFileExists = createMockFileExists(new Set());
+
+            const result = findOutermostProjectFileInParents('/ws/plain/src', '/ws', mockFileExists);
+            assert.strictEqual(result, null);
+        });
+    });
+
+    describe('isPathInside', () => {
+        it('returns true for a nested child', () => {
+            assert.strictEqual(isPathInside('/ws/project/src', '/ws'), true);
+        });
+
+        it('returns true when child equals parent', () => {
+            assert.strictEqual(isPathInside('/ws', '/ws'), true);
+        });
+
+        it('returns false for a sibling path', () => {
+            assert.strictEqual(isPathInside('/other/project', '/ws'), false);
+        });
+
+        it('returns false when child is above parent', () => {
+            assert.strictEqual(isPathInside('/', '/ws'), false);
+        });
+
+        it('is not fooled by same-prefix sibling directory names', () => {
+            assert.strictEqual(isPathInside('/ws-other/src', '/ws'), false);
         });
     });
 

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -69,7 +69,7 @@ export function getWorkspaceRoot(): string | undefined {
  * Skips common non-source directories for performance
  */
 export const WORKSPACE_EXCLUDE_PATTERN =
-    '**/{ node_modules,target,.git,.vscode,.claude,.idea,.settings,build,dist,out,bin}/**';
+    '**/{node_modules,target,.git,.vscode,.claude,.idea,.settings,build,dist,out,bin}/**';
 
 /**
  * Normalize path separators and drive letter case for consistent cache keys

--- a/src/utils/navigationUtils.ts
+++ b/src/utils/navigationUtils.ts
@@ -115,15 +115,23 @@ export function findAttributeValueLocation(
  * Uses two-tier search: package-path match first, then simple name + package verification.
  *
  * @param className - Fully-qualified class name (e.g., "com.example.User")
+ * @param projectRoot - Optional project/module root to scope the search to. When provided,
+ *                      the search is limited to that subtree (RelativePattern) instead of the
+ *                      whole workspace, which keeps lookups fast in multi-project workspaces.
  * @returns The URI of the found file, or null
  */
-export async function findJavaClassFile(className: string): Promise<vscode.Uri | null> {
+export async function findJavaClassFile(
+    className: string,
+    projectRoot?: string
+): Promise<vscode.Uri | null> {
     // Tier 1: Search by fully-qualified path (standard Maven/Gradle layout)
     const pathPattern = className.replace(/\./g, '/') + '.java';
-    const searchPattern = `**/${pathPattern}`;
+    const tier1Include: vscode.GlobPattern = projectRoot
+        ? new vscode.RelativePattern(projectRoot, `**/${pathPattern}`)
+        : `**/${pathPattern}`;
 
     const files = await vscode.workspace.findFiles(
-        searchPattern,
+        tier1Include,
         WORKSPACE_EXCLUDE_PATTERN,
         1
     );
@@ -140,8 +148,12 @@ export async function findJavaClassFile(className: string): Promise<vscode.Uri |
     const simpleName = className.substring(lastDot + 1);
     const expectedPackage = className.substring(0, lastDot);
 
+    const tier2Include: vscode.GlobPattern = projectRoot
+        ? new vscode.RelativePattern(projectRoot, `**/${simpleName}.java`)
+        : `**/${simpleName}.java`;
+
     const fallbackFiles = await vscode.workspace.findFiles(
-        `**/${simpleName}.java`,
+        tier2Include,
         WORKSPACE_EXCLUDE_PATTERN,
         10
     );

--- a/src/utils/projectDetector.ts
+++ b/src/utils/projectDetector.ts
@@ -11,6 +11,21 @@ import * as path from 'path';
  */
 export type FileExistsFn = (filePath: string) => boolean;
 
+const PROJECT_INDICATOR_FILES = ['pom.xml', 'build.gradle', 'build.gradle.kts'];
+
+/**
+ * Return the project indicator file directly inside a directory, or null.
+ */
+function findIndicatorInDir(dir: string, fileExists: FileExistsFn): string | null {
+    for (const name of PROJECT_INDICATOR_FILES) {
+        const indicator = path.join(dir, name);
+        if (fileExists(indicator)) {
+            return indicator;
+        }
+    }
+    return null;
+}
+
 /**
  * Walk up the directory tree to find Java project indicator files (pom.xml, build.gradle, etc.)
  * @param startPath The starting directory path
@@ -27,16 +42,9 @@ export function findProjectFileInParents(
 
     // Search up to maxLevels to prevent infinite recursion
     for (let i = 0; i < maxLevels; i++) {
-        const indicators = [
-            path.join(currentPath, 'pom.xml'),
-            path.join(currentPath, 'build.gradle'),
-            path.join(currentPath, 'build.gradle.kts'),
-        ];
-
-        for (const indicator of indicators) {
-            if (fileExists(indicator)) {
-                return indicator;
-            }
+        const indicator = findIndicatorInDir(currentPath, fileExists);
+        if (indicator) {
+            return indicator;
         }
 
         // Move to parent directory
@@ -49,6 +57,59 @@ export function findProjectFileInParents(
     }
 
     return null;
+}
+
+/**
+ * Walk up from startPath to stopDir (inclusive) and return the OUTERMOST project
+ * indicator file found on the way. In a multi-module Maven/Gradle project this
+ * resolves the aggregate root (the parent pom.xml / root build.gradle) instead of
+ * the nearest module, so lookups can see sibling modules (e.g. mapper XML that
+ * lives in a different module than its Java interface).
+ *
+ * The walk never goes above stopDir, so with one workspace folder containing many
+ * independent services (each with its own build files but no shared parent build
+ * file), each service still resolves to its own root — services are never merged.
+ *
+ * @param startPath Directory to start from (must be inside stopDir; see isPathInside)
+ * @param stopDir Boundary directory, typically the VS Code workspace folder
+ * @param fileExists Function to check file existence (injectable for testing)
+ * @returns The outermost indicator file between startPath and stopDir, or null
+ */
+export function findOutermostProjectFileInParents(
+    startPath: string,
+    stopDir: string,
+    fileExists: FileExistsFn = fs.existsSync
+): string | null {
+    const stop = path.resolve(stopDir);
+    let currentPath = startPath;
+    let outermost: string | null = null;
+
+    // Hard cap as loop safety; the stopDir boundary is the real terminator.
+    for (let i = 0; i < 64; i++) {
+        const indicator = findIndicatorInDir(currentPath, fileExists);
+        if (indicator) {
+            outermost = indicator;
+        }
+
+        if (path.resolve(currentPath) === stop) {
+            break;
+        }
+        const parent = path.dirname(currentPath);
+        if (parent === currentPath) {
+            break;
+        }
+        currentPath = parent;
+    }
+
+    return outermost;
+}
+
+/**
+ * Check whether child is the same directory as parent or nested anywhere below it.
+ */
+export function isPathInside(child: string, parent: string): boolean {
+    const rel = path.relative(parent, child);
+    return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #46 by eliminating the expensive upfront workspace scan that caused activation to take up to 120 seconds in multi-project workspaces. The extension now resolves Java-XML mappings on demand and caches results per project, while activation only wires up file watchers.

## Key Changes

- **Lazy initialization**: `FileMapper.initialize()` no longer calls `scanWorkspace()`. Removed the upfront `findFiles(&#39;**/*.java&#39;)` scan that triggered expensive per-mapper XML lookups.

- **Per-project XML namespace index**: Introduced `xmlIndexByProject` (Map&gt;) that is built once per project on first lookup and cached. Subsequent lookups in the same project reuse the cached index instead of rescanning.

- **Concurrent index build deduplication**: Added `xmlIndexPromises` to ensure multiple concurrent lookups in the same project share a single in-flight index build, preventing duplicate work.

- **Project-scoped file searches**: 
  - `buildProjectXmlIndex()` uses `RelativePattern` to scope XML searches to a single project
  - `findJavaClassFile()` now accepts optional `projectRoot` parameter to scope Java class lookups
  - Both Java→XML and XML→Java resolution now search the owning project first, then fall back to workspace

- **Activation event optimization**: Replaced broad `workspaceContains:**/*.java` with language-based triggers (`onLanguage:java`, `onLanguage:xml`) and build file triggers (`pom.xml`, `build.gradle`, `build.gradle.kts`). This prevents the extension from activating on every Java file in the workspace.

- **Cache invalidation**: Added `invalidateXmlIndexForFile()` to drop the cached namespace index when XML files are created, modified, or deleted, ensuring the index stays fresh.

- **Cross-module XML resolution**: Project roots resolve to the multi-module aggregate root (the outermost build file inside the workspace folder), so mapper XML living in a sibling module of the same project keeps working — a layout the old full-workspace scan supported. The walk never leaves the workspace folder, so independent services sharing one workspace are still never indexed together.

- **Test coverage**: Added unit tests verifying lazy initialization (no workspace scan), per-project index reuse across multiple lookups, cross-module XML resolution via the aggregate root, and service isolation without a shared parent build file.

## Implementation Details

- The namespace index is built by scanning all XML files in a project once and grouping their paths by namespace, enabling O(1) lookups instead of O(mappers × xmlFiles).
- Project root detection uses `findOutermostProjectFileInParents()` to resolve the outermost `pom.xml` / `build.gradle` between a file and its workspace folder (the aggregate root of a multi-module project), with fallback to the enclosing workspace folder.
- File watcher handlers now invalidate the project index when XML files change, ensuring consistency without full rescans.
- The `WORKSPACE_EXCLUDE_PATTERN` was corrected to remove the leading space that broke the first exclusion pattern.

https://claude.ai/code/session_01T5DYtbF7fBXJ7B5rQp6FEf