### PR TITLE
Support inherited fields in parameter validation and navigation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -68,7 +68,8 @@
       "Bash($null)",
       "Bash(rm:*)",
       "WebSearch",
-      "WebFetch(domain:github.com)"
+      "WebFetch(domain:github.com)",
+      "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); print\\(json.dumps\\(d['scripts'], indent=2\\)\\)\")"
     ],
     "deny": [
       "Bash(rm -rf /*)",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,12 +17,27 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"args": [
+				"--disable-extension",
+				"vscjava.vscode-java-debug",
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
 			"outFiles": [
 				"${workspaceFolder}/dist/**/*.js"
 			],
-			"preLaunchTask": "pnpm: compile"
+			"preLaunchTask": "corepack: compile"
+		},
+		{
+			"name": "Run Extension (Isolated)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"outFiles": [
+				"${workspaceFolder}/dist/**/*.js"
+			],
+			"preLaunchTask": "corepack: compile"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -62,9 +62,9 @@
 		},
 		{
 			"type": "shell",
-			"command": "pnpm run compile",
+			"command": "corepack pnpm run compile",
 			"problemMatcher": "$tsc",
-			"label": "pnpm: compile",
+			"label": "corepack: compile",
 			"detail": "Compile extension before launch",
 			"presentation": {
 				"reveal": "silent",

--- a/esbuild.js
+++ b/esbuild.js
@@ -6,6 +6,23 @@ const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
 
 /**
+ * Force the CommonJS entry of web-tree-sitter when bundling the CommonJS
+ * extension. Its ESM entry depends on import.meta.url, which esbuild cannot
+ * preserve in CJS output and replaces with an empty object.
+ * @type {import('esbuild').Plugin}
+ */
+const webTreeSitterCjsPlugin = {
+	name: 'web-tree-sitter-cjs',
+
+	setup(build) {
+		const cjsEntry = require.resolve('web-tree-sitter');
+		build.onResolve({ filter: /^web-tree-sitter$/ }, () => ({
+			path: cjsEntry,
+		}));
+	},
+};
+
+/**
  * @type {import('esbuild').Plugin}
  */
 const esbuildProblemMatcherPlugin = {
@@ -110,6 +127,7 @@ async function main() {
 		external: ['vscode'],
 		logLevel: 'silent',
 		plugins: [
+			webTreeSitterCjsPlugin,
 			copyResourcesPlugin,
 			/* add to the end of plugins array */
 			esbuildProblemMatcherPlugin,

--- a/java-project/integration-test/src/main/java/com/young1lin/mybatis/boost/integration/test/inheritance/audit/NavigationAuditEntity.java
+++ b/java-project/integration-test/src/main/java/com/young1lin/mybatis/boost/integration/test/inheritance/audit/NavigationAuditEntity.java
@@ -1,0 +1,22 @@
+package com.young1lin.mybatis.boost.integration.test.inheritance.audit;
+
+import com.young1lin.mybatis.boost.integration.test.inheritance.base.NavigationBaseEntity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Second level of the manual navigation fixture.
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class NavigationAuditEntity extends NavigationBaseEntity<Long> {
+
+    private String updatedBy;
+
+    /**
+     * Shadows NavigationBaseEntity.fieldA. MyBatis property navigation for
+     * "fieldA" must stop here because this is the nearest declaration.
+     */
+    private String fieldA;
+}

--- a/java-project/integration-test/src/main/java/com/young1lin/mybatis/boost/integration/test/inheritance/base/NavigationBaseEntity.java
+++ b/java-project/integration-test/src/main/java/com/young1lin/mybatis/boost/integration/test/inheritance/base/NavigationBaseEntity.java
@@ -1,0 +1,28 @@
+package com.young1lin.mybatis.boost.integration.test.inheritance.base;
+
+import lombok.Data;
+
+/**
+ * First level of the manual navigation fixture.
+ */
+@Data
+public class NavigationBaseEntity<ID> {
+
+    private ID id;
+
+    private String createdBy;
+
+    private String baseOnlyField;
+
+    /**
+     * Deliberately shadowed by NavigationAuditEntity.
+     */
+    private String fieldA;
+
+    /**
+     * The annotation makes this field unsuitable for the old line-based parser,
+     * so navigation to it also exercises the bundled Java AST parser.
+     */
+    @Deprecated
+    private String astOnlyField;
+}

--- a/java-project/integration-test/src/main/java/com/young1lin/mybatis/boost/integration/test/inheritance/query/NavigationTaskQuery.java
+++ b/java-project/integration-test/src/main/java/com/young1lin/mybatis/boost/integration/test/inheritance/query/NavigationTaskQuery.java
@@ -1,0 +1,19 @@
+package com.young1lin.mybatis.boost.integration.test.inheritance.query;
+
+import com.young1lin.mybatis.boost.integration.test.inheritance.audit.NavigationAuditEntity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Third level of the manual navigation fixture:
+ * NavigationTaskQuery -> NavigationAuditEntity -> NavigationBaseEntity.
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class NavigationTaskQuery extends NavigationAuditEntity {
+
+    private String taskName;
+
+    private Integer status;
+}

--- a/java-project/integration-test/src/main/java/com/young1lin/mybatis/boost/integration/test/mapper/InheritanceNavigationMapper.java
+++ b/java-project/integration-test/src/main/java/com/young1lin/mybatis/boost/integration/test/mapper/InheritanceNavigationMapper.java
@@ -1,0 +1,18 @@
+package com.young1lin.mybatis.boost.integration.test.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.young1lin.mybatis.boost.integration.test.inheritance.query.NavigationTaskQuery;
+
+/**
+ * Manual fixture for XML-to-Java field navigation through multiple superclasses.
+ */
+@Mapper
+public interface InheritanceNavigationMapper {
+
+    List<NavigationTaskQuery> selectByCondition(NavigationTaskQuery condition);
+
+    int countByCondition(NavigationTaskQuery condition);
+}

--- a/java-project/integration-test/src/main/resources/mapper/InheritanceNavigationMapper.xml
+++ b/java-project/integration-test/src/main/resources/mapper/InheritanceNavigationMapper.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.young1lin.mybatis.boost.integration.test.mapper.InheritanceNavigationMapper">
+
+    <!--
+        Manual navigation expectations:
+        - taskName      -> NavigationTaskQuery (current class)
+        - updatedBy     -> NavigationAuditEntity (one level up)
+        - id/createdBy  -> NavigationBaseEntity (two levels up)
+        - astOnlyField  -> NavigationBaseEntity (annotated AST-only field)
+        - fieldA        -> NavigationAuditEntity (nearest declaration wins)
+    -->
+    <resultMap id="NavigationTaskResultMap"
+               type="com.young1lin.mybatis.boost.integration.test.inheritance.query.NavigationTaskQuery">
+        <id property="id" column="id"/>
+        <result property="createdBy" column="created_by"/>
+        <result property="baseOnlyField" column="base_only_field"/>
+        <result property="astOnlyField" column="ast_only_field"/>
+        <result property="updatedBy" column="updated_by"/>
+        <result property="fieldA" column="field_a"/>
+        <result property="taskName" column="task_name"/>
+        <result property="status" column="status"/>
+    </resultMap>
+
+    <select id="selectByCondition" resultMap="NavigationTaskResultMap">
+        SELECT
+            id,
+            created_by,
+            base_only_field,
+            ast_only_field,
+            updated_by,
+            field_a,
+            task_name,
+            status
+        FROM navigation_task
+        <where>
+            <if test="taskName != null">
+                AND task_name = #{taskName}
+            </if>
+            <if test="updatedBy != null">
+                AND updated_by = #{updatedBy}
+            </if>
+            <if test="createdBy != null">
+                AND created_by = #{createdBy}
+            </if>
+            <if test="baseOnlyField != null">
+                AND base_only_field = #{baseOnlyField}
+            </if>
+            <if test="astOnlyField != null">
+                AND ast_only_field = #{astOnlyField}
+            </if>
+            <if test="fieldA != null">
+                AND field_a = #{fieldA}
+            </if>
+            <if test="id != null">
+                AND id = #{id}
+            </if>
+        </where>
+    </select>
+
+    <select id="countByCondition"
+            parameterType="com.young1lin.mybatis.boost.integration.test.inheritance.query.NavigationTaskQuery"
+            resultType="int">
+        SELECT COUNT(*)
+        FROM navigation_task
+        WHERE created_by = #{createdBy}
+          AND updated_by = #{updatedBy}
+          AND field_a = #{fieldA}
+    </select>
+
+</mapper>

--- a/package.json
+++ b/package.json
@@ -334,7 +334,7 @@
   },
   "scripts": {
     "vscode:prepublish": "pnpm run package",
-    "compile": "pnpm run check-types && pnpm run lint && node esbuild.js",
+    "compile": "tsc --noEmit && eslint src && node esbuild.js",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",

--- a/src/navigator/diagnostics/ParameterValidator.ts
+++ b/src/navigator/diagnostics/ParameterValidator.ts
@@ -24,6 +24,9 @@ export class ParameterValidator {
     // Maps each class in a cached inheritance chain to the cache keys that
     // include its fields, so editing a superclass invalidates subclass entries
     private classDependents: Map<string, Set<string>> = new Map();
+    // Forward index: cache key → its inheritance chain, so entries leaving the
+    // cache (invalidation or LRU eviction) can be removed from classDependents
+    private dependencyChains: Map<string, string[]> = new Map();
     private readonly DEBOUNCE_DELAY = 500; // 500ms debounce for text changes
     private readonly FIELD_CACHE_SIZE = 200; // Cache up to 200 classes
     private enabled: boolean;
@@ -36,8 +39,9 @@ export class ParameterValidator {
         this.diagnosticCollection = vscode.languages.createDiagnosticCollection('mybatis-parameters');
         this.context.subscriptions.push(this.diagnosticCollection);
 
-        // Initialize field cache
-        this.fieldCache = new LRUCache(this.FIELD_CACHE_SIZE);
+        // Initialize field cache; silently evicted entries must also drop their
+        // dependency bookkeeping so classDependents cannot outgrow the cache
+        this.fieldCache = new LRUCache(this.FIELD_CACHE_SIZE, key => this.unregisterHierarchy(key));
 
         // Read initial configuration
         this.enabled = this.isValidationEnabled();
@@ -409,6 +413,7 @@ export class ParameterValidator {
             this.fieldCache.set(className, fieldNames);
 
             // 4. Record that editing any class in the chain invalidates this entry
+            this.dependencyChains.set(className, classChain);
             for (const chainClass of classChain) {
                 let dependents = this.classDependents.get(chainClass);
                 if (!dependents) {
@@ -441,10 +446,15 @@ export class ParameterValidator {
             }
 
             this.fieldCache.delete(className);
+            this.unregisterHierarchy(className);
 
             const dependents = this.classDependents.get(className);
             if (dependents) {
-                dependents.forEach(dependent => this.fieldCache.delete(dependent));
+                // Copy first: unregisterHierarchy prunes the set being iterated
+                for (const dependent of [...dependents]) {
+                    this.fieldCache.delete(dependent);
+                    this.unregisterHierarchy(dependent);
+                }
                 this.classDependents.delete(className);
             }
 
@@ -455,11 +465,35 @@ export class ParameterValidator {
     }
 
     /**
+     * Remove a cache key's dependency bookkeeping when its entry leaves the
+     * field cache (explicit invalidation or silent LRU eviction), so
+     * classDependents stays bounded by the cache contents
+     */
+    private unregisterHierarchy(cacheKey: string): void {
+        const chain = this.dependencyChains.get(cacheKey);
+        if (!chain) {
+            return;
+        }
+        this.dependencyChains.delete(cacheKey);
+
+        for (const chainClass of chain) {
+            const dependents = this.classDependents.get(chainClass);
+            if (dependents) {
+                dependents.delete(cacheKey);
+                if (dependents.size === 0) {
+                    this.classDependents.delete(chainClass);
+                }
+            }
+        }
+    }
+
+    /**
      * Clear the field cache and its inheritance dependency tracking
      */
     private clearFieldCache(): void {
         this.fieldCache.clear();
         this.classDependents.clear();
+        this.dependencyChains.clear();
     }
 
     /**

--- a/src/navigator/diagnostics/ParameterValidator.ts
+++ b/src/navigator/diagnostics/ParameterValidator.ts
@@ -94,11 +94,15 @@ export class ParameterValidator {
             })
         );
 
-        // Invalidate field cache when Java files are saved (for external changes)
+        // Invalidate field cache when Java files are saved, and refresh diagnostics
+        // of open XML documents so stale field errors don't linger until the next
+        // XML edit (the fs watcher below also fires on save, but this does not
+        // depend on watcher timing)
         this.disposables.push(
             vscode.workspace.onDidSaveTextDocument(doc => {
                 if (doc.languageId === 'java') {
                     this.invalidateFieldCache(doc.uri.fsPath);
+                    this.revalidateOpenXmlDocuments();
                 }
             })
         );

--- a/src/navigator/diagnostics/ParameterValidator.ts
+++ b/src/navigator/diagnostics/ParameterValidator.ts
@@ -8,12 +8,10 @@ import { FileMapper } from '../core/FileMapper';
 import { extractParameterReferences, extractStatementParameterInfo, extractLocalVariables, extractAttributeReferences } from '../parsers/parameterParser';
 import { extractXmlStatements } from '../parsers/xmlParser';
 import { extractMethodParameters } from '../parsers/javaParser';
-import { extractJavaFields } from '../parsers/javaFieldParser';
 import { LRUCache } from '../../utils/LRUCache';
 import { isBuiltInType, isCollectionType } from '../../utils/javaTypeUtils';
 import { resolveFullyQualifiedType } from '../../utils/javaTypeResolver';
-import { WORKSPACE_EXCLUDE_PATTERN } from '../../utils/fileUtils';
-import { findJavaClassFile } from '../../utils/navigationUtils';
+import { getClassFieldsWithInheritance } from '../../utils/javaFieldHierarchy';
 
 /**
  * Validates parameters in XML mapper files
@@ -23,6 +21,9 @@ export class ParameterValidator {
     private disposables: vscode.Disposable[] = [];
     private validationTimers: Map<string, NodeJS.Timeout> = new Map();
     private fieldCache: LRUCache<string, string[]>;
+    // Maps each class in a cached inheritance chain to the cache keys that
+    // include its fields, so editing a superclass invalidates subclass entries
+    private classDependents: Map<string, Set<string>> = new Map();
     private readonly DEBOUNCE_DELAY = 500; // 500ms debounce for text changes
     private readonly FIELD_CACHE_SIZE = 200; // Cache up to 200 classes
     private enabled: boolean;
@@ -105,15 +106,15 @@ export class ParameterValidator {
         // Watch Java files at filesystem level for external changes (git checkout, etc.)
         const javaFsWatcher = vscode.workspace.createFileSystemWatcher('**/*.java');
         javaFsWatcher.onDidChange(() => {
-            this.fieldCache.clear();
+            this.clearFieldCache();
             this.revalidateOpenXmlDocuments();
         });
         javaFsWatcher.onDidCreate(() => {
-            this.fieldCache.clear();
+            this.clearFieldCache();
             this.revalidateOpenXmlDocuments();
         });
         javaFsWatcher.onDidDelete(() => {
-            this.fieldCache.clear();
+            this.clearFieldCache();
             this.revalidateOpenXmlDocuments();
         });
         this.disposables.push(javaFsWatcher);
@@ -383,7 +384,7 @@ export class ParameterValidator {
     }
 
     /**
-     * Get field names from a Java class (with caching)
+     * Get field names from a Java class, including inherited fields (with caching)
      */
     private async getClassFields(className: string): Promise<string[]> {
         // 1. Check cache first
@@ -393,26 +394,27 @@ export class ParameterValidator {
             return cached;
         }
 
-        // 2. Cache miss - search and parse
+        // 2. Cache miss - walk the class hierarchy and collect fields
         console.log(`[ParameterValidator] Cache miss for class: ${className}, searching...`);
 
         try {
-            const file = await findJavaClassFile(className);
+            const { fields, classChain } = await getClassFieldsWithInheritance(className);
+            const fieldNames = fields.map(f => f.field.name);
 
-            if (!file) {
-                console.log(`[ParameterValidator] Class not found: ${className}`);
-                // Cache empty result to avoid repeated searches
-                this.fieldCache.set(className, []);
-                return [];
+            // 3. Store in cache; empty results are cached too, to avoid repeated searches
+            this.fieldCache.set(className, fieldNames);
+
+            // 4. Record that editing any class in the chain invalidates this entry
+            for (const chainClass of classChain) {
+                let dependents = this.classDependents.get(chainClass);
+                if (!dependents) {
+                    dependents = new Set();
+                    this.classDependents.set(chainClass, dependents);
+                }
+                dependents.add(className);
             }
 
-            const fields = await extractJavaFields(file.fsPath);
-            const fieldNames = fields.map(f => f.name);
-
-            // 3. Store in cache
-            this.fieldCache.set(className, fieldNames);
             console.log(`[ParameterValidator] Cached fields for ${className}: ${fieldNames.join(', ')}`);
-
             return fieldNames;
 
         } catch (error) {
@@ -422,20 +424,38 @@ export class ParameterValidator {
     }
 
     /**
-     * Invalidate field cache for a specific Java file
+     * Invalidate field cache for a specific Java file.
+     * Also invalidates cached entries of subclasses that inherited its fields.
      */
     private invalidateFieldCache(javaPath: string): void {
         try {
             // Extract class name from file path
             // Example: /path/to/src/main/java/com/example/User.java → com.example.User
             const className = this.getClassNameFromPath(javaPath);
-            if (className) {
-                this.fieldCache.delete(className);
-                console.log(`[ParameterValidator] Invalidated field cache for: ${className}`);
+            if (!className) {
+                return;
             }
+
+            this.fieldCache.delete(className);
+
+            const dependents = this.classDependents.get(className);
+            if (dependents) {
+                dependents.forEach(dependent => this.fieldCache.delete(dependent));
+                this.classDependents.delete(className);
+            }
+
+            console.log(`[ParameterValidator] Invalidated field cache for: ${className}`);
         } catch (error) {
             console.error(`[ParameterValidator] Error invalidating field cache:`, error);
         }
+    }
+
+    /**
+     * Clear the field cache and its inheritance dependency tracking
+     */
+    private clearFieldCache(): void {
+        this.fieldCache.clear();
+        this.classDependents.clear();
     }
 
     /**
@@ -524,7 +544,7 @@ export class ParameterValidator {
         this.validationTimers.clear();
 
         // Clear field cache
-        this.fieldCache.clear();
+        this.clearFieldCache();
 
         this.diagnosticCollection.dispose();
         this.disposables.forEach(d => d.dispose());

--- a/src/navigator/diagnostics/ParameterValidator.ts
+++ b/src/navigator/diagnostics/ParameterValidator.ts
@@ -412,7 +412,10 @@ export class ParameterValidator {
             // 3. Store in cache; empty results are cached too, to avoid repeated searches
             this.fieldCache.set(className, fieldNames);
 
-            // 4. Record that editing any class in the chain invalidates this entry
+            // 4. Record that editing any class in the chain invalidates this entry.
+            // Drop any previous registration first: overlapping cache misses for
+            // the same key would otherwise leave links from a superseded chain
+            this.unregisterHierarchy(className);
             this.dependencyChains.set(className, classChain);
             for (const chainClass of classChain) {
                 let dependents = this.classDependents.get(chainClass);

--- a/src/navigator/index.ts
+++ b/src/navigator/index.ts
@@ -24,4 +24,4 @@ export { ParameterValidator } from './diagnostics/ParameterValidator';
 export { extractJavaNamespace, isMyBatisMapper, extractJavaMethods, extractJavaMethodsFromContent, findJavaMethodLine, findJavaMethodPosition, extractMethodParameters } from './parsers/javaParser';
 export { extractXmlNamespace, extractXmlStatements, findXmlStatementLine, findXmlStatementPosition, extractStatementIdFromPosition, findXmlMapperPosition } from './parsers/xmlParser';
 export { extractParameterReferences, extractStatementParameterInfo, getParameterAtPosition } from './parsers/parameterParser';
-export { extractJavaFields, findJavaField, findJavaFieldPosition } from './parsers/javaFieldParser';
+export { extractJavaFields, findJavaField, findJavaFieldPosition, extractSuperclassName } from './parsers/javaFieldParser';

--- a/src/navigator/parsers/javaFieldParser.ts
+++ b/src/navigator/parsers/javaFieldParser.ts
@@ -6,7 +6,7 @@
 
 import { JavaField } from '../../types';
 import { readFile } from '../../utils/fileUtils';
-import { extractFieldsFromAST } from './javaTreeSitterParser';
+import { extractFieldsFromAST, extractSuperclassNameFromAST } from './javaTreeSitterParser';
 import { getClassFieldsViaLS } from '../../utils/javaLSHelper';
 
 /**
@@ -84,7 +84,35 @@ export async function findJavaFieldPosition(
     return null;
 }
 
+/**
+ * Extract the superclass name declared in a Java class file's `extends` clause
+ *
+ * Two-tier fallback: WASM (tree-sitter) → Regex
+ *
+ * @param filePath - Path to Java file
+ * @returns Superclass name as written in source (simple or fully-qualified,
+ *          without generic type arguments), or null when the class extends nothing
+ */
+export async function extractSuperclassName(filePath: string): Promise<string | null> {
+    const content = await readFile(filePath);
+
+    // Tier 1: WASM (tree-sitter)
+    try {
+        return await extractSuperclassNameFromAST(content);
+    } catch { /* fallthrough */ }
+
+    // Tier 2: Regex fallback
+    return extractSuperclassNameRegex(content);
+}
+
 // ==================== Regex fallback implementation ====================
+
+function extractSuperclassNameRegex(content: string): string | null {
+    // The optional generic group keeps bounded type parameters like
+    // "class Child<T extends Number> extends Base" from capturing "Number"
+    const match = content.match(/\bclass\s+\w+(?:\s*<[^>]*>)?\s+extends\s+([\w.]+)/);
+    return match ? match[1] : null;
+}
 
 function extractJavaFieldsRegex(content: string): JavaField[] {
     const lines = content.split('\n');

--- a/src/navigator/parsers/javaFieldParser.ts
+++ b/src/navigator/parsers/javaFieldParser.ts
@@ -151,7 +151,12 @@ function extractJavaFieldsRegex(content: string, className?: string): JavaField[
 
         if (/(?:class|interface|enum)\s+\w+/.test(line)) {
             inClassBody = false;
-            if (className) {
+            // Only top-level declarations (braceLevel 0) change which class we
+            // are in. Nested type declarations must not clear the flag: their
+            // own fields sit deeper than braceLevel 1 and are excluded by the
+            // depth check, while the outer class's fields after the nested
+            // type still belong to the target class.
+            if (className && braceLevel === 0) {
                 inTargetClass = new RegExp(`\\b(?:class|interface|enum)\\s+${escapeRegex(className)}\\b`).test(line);
             }
         }

--- a/src/navigator/parsers/javaFieldParser.ts
+++ b/src/navigator/parsers/javaFieldParser.ts
@@ -16,26 +16,28 @@ import { getClassFieldsViaLS } from '../../utils/javaLSHelper';
  * Three-tier fallback: WASM (tree-sitter) → Java LS → Regex
  *
  * @param filePath - Path to Java file
+ * @param className - When given, extraction is scoped to that class declaration
+ *                    so other types in the same file cannot contribute fields
  * @returns Array of field information
  */
-export async function extractJavaFields(filePath: string): Promise<JavaField[]> {
+export async function extractJavaFields(filePath: string, className?: string): Promise<JavaField[]> {
     const content = await readFile(filePath);
 
     // Tier 1: WASM (tree-sitter)
     try {
-        return await extractFieldsFromAST(content);
+        return await extractFieldsFromAST(content, className);
     } catch { /* fallthrough */ }
 
     // Tier 2: Java Language Server
     try {
-        const lsFields = await getClassFieldsViaLS(filePath);
+        const lsFields = await getClassFieldsViaLS(filePath, className);
         if (lsFields) {
             return lsFields;
         }
     } catch { /* fallthrough */ }
 
     // Tier 3: Regex fallback
-    return extractJavaFieldsRegex(content);
+    return extractJavaFieldsRegex(content, className);
 }
 
 /**
@@ -121,23 +123,27 @@ function extractSuperclassNameRegex(content: string, className?: string): string
         .replace(/\/\/[^\n]*/g, ' ');
 
     // The optional generic group keeps bounded type parameters like
-    // "class Child<T extends Number> extends Base" from capturing "Number".
+    // "class Child<T extends Number> extends Base" from capturing "Number",
+    // and supports one level of nested generics such as
+    // "class Foo<T extends Comparable<String>> extends Base".
     // Anchoring on the class name keeps other types in the same file from
     // being mistaken for the class's superclass.
     const classToken = className ? escapeRegex(className) : '\\w+';
     const superclassRegex = new RegExp(
-        `\\bclass\\s+${classToken}(?:\\s*<[^>]*>)?\\s+extends\\s+([\\w.]+)`
+        `\\bclass\\s+${classToken}(?:\\s*<(?:[^<>]|<[^<>]*>)*>)?\\s+extends\\s+([\\w.]+)`
     );
     const match = withoutComments.match(superclassRegex);
     return match ? match[1] : null;
 }
 
-function extractJavaFieldsRegex(content: string): JavaField[] {
+function extractJavaFieldsRegex(content: string, className?: string): JavaField[] {
     const lines = content.split('\n');
     const fields: JavaField[] = [];
 
     let inClassBody = false;
     let braceLevel = 0;
+    // When scoped to a class, only collect fields while inside that class's body
+    let inTargetClass = !className;
 
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
@@ -145,6 +151,9 @@ function extractJavaFieldsRegex(content: string): JavaField[] {
 
         if (/(?:class|interface|enum)\s+\w+/.test(line)) {
             inClassBody = false;
+            if (className) {
+                inTargetClass = new RegExp(`\\b(?:class|interface|enum)\\s+${escapeRegex(className)}\\b`).test(line);
+            }
         }
 
         braceLevel += (line.match(/{/g) || []).length;
@@ -154,7 +163,7 @@ function extractJavaFieldsRegex(content: string): JavaField[] {
             inClassBody = true;
         }
 
-        if (!inClassBody || braceLevel !== 1) {
+        if (!inClassBody || braceLevel !== 1 || !inTargetClass) {
             continue;
         }
 

--- a/src/navigator/parsers/javaFieldParser.ts
+++ b/src/navigator/parsers/javaFieldParser.ts
@@ -6,6 +6,7 @@
 
 import { JavaField } from '../../types';
 import { readFile } from '../../utils/fileUtils';
+import { escapeRegex } from '../../utils/stringUtils';
 import { extractFieldsFromAST, extractSuperclassNameFromAST } from './javaTreeSitterParser';
 import { getClassFieldsViaLS } from '../../utils/javaLSHelper';
 
@@ -90,27 +91,44 @@ export async function findJavaFieldPosition(
  * Two-tier fallback: WASM (tree-sitter) → Regex
  *
  * @param filePath - Path to Java file
+ * @param className - When given, only that class declaration is inspected, so
+ *                    other types in the same file cannot be mistaken for the
+ *                    class's superclass
  * @returns Superclass name as written in source (simple or fully-qualified,
  *          without generic type arguments), or null when the class extends nothing
  */
-export async function extractSuperclassName(filePath: string): Promise<string | null> {
+export async function extractSuperclassName(
+    filePath: string,
+    className?: string
+): Promise<string | null> {
     const content = await readFile(filePath);
 
     // Tier 1: WASM (tree-sitter)
     try {
-        return await extractSuperclassNameFromAST(content);
+        return await extractSuperclassNameFromAST(content, className);
     } catch { /* fallthrough */ }
 
     // Tier 2: Regex fallback
-    return extractSuperclassNameRegex(content);
+    return extractSuperclassNameRegex(content, className);
 }
 
 // ==================== Regex fallback implementation ====================
 
-function extractSuperclassNameRegex(content: string): string | null {
+function extractSuperclassNameRegex(content: string, className?: string): string | null {
+    // Strip comments so "// class Foo extends Bar" cannot produce a false match
+    const withoutComments = content
+        .replace(/\/\*[\s\S]*?\*\//g, ' ')
+        .replace(/\/\/[^\n]*/g, ' ');
+
     // The optional generic group keeps bounded type parameters like
-    // "class Child<T extends Number> extends Base" from capturing "Number"
-    const match = content.match(/\bclass\s+\w+(?:\s*<[^>]*>)?\s+extends\s+([\w.]+)/);
+    // "class Child<T extends Number> extends Base" from capturing "Number".
+    // Anchoring on the class name keeps other types in the same file from
+    // being mistaken for the class's superclass.
+    const classToken = className ? escapeRegex(className) : '\\w+';
+    const superclassRegex = new RegExp(
+        `\\bclass\\s+${classToken}(?:\\s*<[^>]*>)?\\s+extends\\s+([\\w.]+)`
+    );
+    const match = withoutComments.match(superclassRegex);
     return match ? match[1] : null;
 }
 

--- a/src/navigator/parsers/javaTreeSitterParser.ts
+++ b/src/navigator/parsers/javaTreeSitterParser.ts
@@ -96,6 +96,37 @@ function parseContent(content: string): TSNode {
     return tree.rootNode;
 }
 
+const TYPE_DECLARATION_NODE_TYPES = new Set([
+    'class_declaration',
+    'interface_declaration',
+    'enum_declaration',
+    'record_declaration',
+    'annotation_type_declaration'
+]);
+
+/**
+ * Match a source-file type by simple name without accepting a same-named
+ * nested or local type. Hierarchy resolution starts from a Java source file
+ * selected by fully-qualified top-level class name, so nested declarations
+ * represent different binary types and must not contribute fields or parents.
+ */
+function isRequestedTopLevelType(node: TSNode, className: string): boolean {
+    const nameNode = node.childForFieldName('name');
+    if (!nameNode || nameNode.text !== className) {
+        return false;
+    }
+
+    let ancestor = node.parent;
+    while (ancestor) {
+        if (TYPE_DECLARATION_NODE_TYPES.has(ancestor.type)) {
+            return false;
+        }
+        ancestor = ancestor.parent;
+    }
+
+    return true;
+}
+
 /**
  * Extract all methods from a Java mapper interface using AST.
  */
@@ -284,11 +315,11 @@ export async function extractParametersFromAST(
  * Extract all fields from a Java class using AST.
  *
  * @param content - Java source content
- * @param className - When given, only the matching class/interface declaration's
- *                    own fields are returned (direct members, excluding nested
- *                    types), so other types in the same compilation unit cannot
- *                    leak into the result. When omitted, fields of all types in
- *                    the file are merged (legacy behavior).
+ * @param className - When given, only the matching top-level class/interface
+ *                    declaration's own fields are returned (direct members,
+ *                    excluding nested types), so other types in the same
+ *                    compilation unit cannot leak into the result. When omitted,
+ *                    fields of all types in the file are merged (legacy behavior).
  */
 export async function extractFieldsFromAST(
     content: string,
@@ -303,11 +334,8 @@ export async function extractFieldsFromAST(
     // Find class declarations (and also check interface body for constant fields)
     const classDecls = root.descendantsOfType(['class_declaration', 'interface_declaration']);
     for (const cls of classDecls) {
-        if (className) {
-            const nameNode = cls.childForFieldName('name');
-            if (!nameNode || nameNode.text !== className) {
-                continue;
-            }
+        if (className && !isRequestedTopLevelType(cls, className)) {
+            continue;
         }
 
         const body = cls.childForFieldName('body');
@@ -362,10 +390,10 @@ export async function extractFieldsFromAST(
  * (e.g., `extends BaseEntity<Long>` → "BaseEntity").
  *
  * @param content - Java source content
- * @param className - When given, only that class declaration is inspected, so
- *                    other types in the same compilation unit cannot be
- *                    mistaken for the class's superclass. When omitted, the
- *                    first class declaration with an `extends` clause is used.
+ * @param className - When given, only that top-level class declaration is
+ *                    inspected, so other types in the same compilation unit
+ *                    cannot be mistaken for the class's superclass. When omitted,
+ *                    the first class declaration with an `extends` clause is used.
  * @returns Superclass name as written in source (simple or fully-qualified), or null
  */
 export async function extractSuperclassNameFromAST(
@@ -379,11 +407,8 @@ export async function extractSuperclassNameFromAST(
 
     const classDecls = root.descendantsOfType('class_declaration');
     for (const cls of classDecls) {
-        if (className) {
-            const nameNode = cls.childForFieldName('name');
-            if (!nameNode || nameNode.text !== className) {
-                continue;
-            }
+        if (className && !isRequestedTopLevelType(cls, className)) {
+            continue;
         }
 
         const superclassNode = cls.childForFieldName('superclass');

--- a/src/navigator/parsers/javaTreeSitterParser.ts
+++ b/src/navigator/parsers/javaTreeSitterParser.ts
@@ -282,8 +282,18 @@ export async function extractParametersFromAST(
 
 /**
  * Extract all fields from a Java class using AST.
+ *
+ * @param content - Java source content
+ * @param className - When given, only the matching class/interface declaration's
+ *                    own fields are returned (direct members, excluding nested
+ *                    types), so other types in the same compilation unit cannot
+ *                    leak into the result. When omitted, fields of all types in
+ *                    the file are merged (legacy behavior).
  */
-export async function extractFieldsFromAST(content: string): Promise<JavaField[]> {
+export async function extractFieldsFromAST(
+    content: string,
+    className?: string
+): Promise<JavaField[]> {
     if (!await initTreeSitter()) {
         throw new Error('Tree-sitter not available');
     }
@@ -293,12 +303,23 @@ export async function extractFieldsFromAST(content: string): Promise<JavaField[]
     // Find class declarations (and also check interface body for constant fields)
     const classDecls = root.descendantsOfType(['class_declaration', 'interface_declaration']);
     for (const cls of classDecls) {
+        if (className) {
+            const nameNode = cls.childForFieldName('name');
+            if (!nameNode || nameNode.text !== className) {
+                continue;
+            }
+        }
+
         const body = cls.childForFieldName('body');
         if (!body) {
             continue;
         }
 
-        const fieldDecls = body.descendantsOfType('field_declaration');
+        // Scoped extraction takes only the class's direct members so nested
+        // types' fields are not attributed to the class itself
+        const fieldDecls = className
+            ? body.namedChildren.filter((c): c is TSNode => c !== null && c.type === 'field_declaration')
+            : body.descendantsOfType('field_declaration');
         for (const fd of fieldDecls) {
             const declarator = fd.descendantsOfType('variable_declarator')[0];
             if (!declarator) {

--- a/src/navigator/parsers/javaTreeSitterParser.ts
+++ b/src/navigator/parsers/javaTreeSitterParser.ts
@@ -336,13 +336,21 @@ export async function extractFieldsFromAST(content: string): Promise<JavaField[]
 }
 
 /**
- * Extract the superclass name from the first class declaration with an
- * `extends` clause using AST. Generic type arguments are stripped
+ * Extract the superclass name from a class declaration's `extends` clause
+ * using AST. Generic type arguments are stripped
  * (e.g., `extends BaseEntity<Long>` → "BaseEntity").
  *
+ * @param content - Java source content
+ * @param className - When given, only that class declaration is inspected, so
+ *                    other types in the same compilation unit cannot be
+ *                    mistaken for the class's superclass. When omitted, the
+ *                    first class declaration with an `extends` clause is used.
  * @returns Superclass name as written in source (simple or fully-qualified), or null
  */
-export async function extractSuperclassNameFromAST(content: string): Promise<string | null> {
+export async function extractSuperclassNameFromAST(
+    content: string,
+    className?: string
+): Promise<string | null> {
     if (!await initTreeSitter()) {
         throw new Error('Tree-sitter not available');
     }
@@ -350,8 +358,19 @@ export async function extractSuperclassNameFromAST(content: string): Promise<str
 
     const classDecls = root.descendantsOfType('class_declaration');
     for (const cls of classDecls) {
+        if (className) {
+            const nameNode = cls.childForFieldName('name');
+            if (!nameNode || nameNode.text !== className) {
+                continue;
+            }
+        }
+
         const superclassNode = cls.childForFieldName('superclass');
         if (!superclassNode) {
+            if (className) {
+                // The requested class extends nothing
+                return null;
+            }
             continue;
         }
 

--- a/src/navigator/parsers/javaTreeSitterParser.ts
+++ b/src/navigator/parsers/javaTreeSitterParser.ts
@@ -336,6 +336,41 @@ export async function extractFieldsFromAST(content: string): Promise<JavaField[]
 }
 
 /**
+ * Extract the superclass name from the first class declaration with an
+ * `extends` clause using AST. Generic type arguments are stripped
+ * (e.g., `extends BaseEntity<Long>` → "BaseEntity").
+ *
+ * @returns Superclass name as written in source (simple or fully-qualified), or null
+ */
+export async function extractSuperclassNameFromAST(content: string): Promise<string | null> {
+    if (!await initTreeSitter()) {
+        throw new Error('Tree-sitter not available');
+    }
+    const root = parseContent(content);
+
+    const classDecls = root.descendantsOfType('class_declaration');
+    for (const cls of classDecls) {
+        const superclassNode = cls.childForFieldName('superclass');
+        if (!superclassNode) {
+            continue;
+        }
+
+        // The superclass node text is "extends TypeName[<...>]"
+        let name = superclassNode.text.replace(/^extends\s+/, '').trim();
+        const genericIdx = name.indexOf('<');
+        if (genericIdx >= 0) {
+            name = name.substring(0, genericIdx).trim();
+        }
+
+        if (name) {
+            return name;
+        }
+    }
+
+    return null;
+}
+
+/**
  * Extract namespace (package.InterfaceName) from Java content using AST.
  */
 export async function extractNamespaceFromAST(content: string): Promise<string | null> {

--- a/src/navigator/providers/XmlParameterDefinitionProvider.ts
+++ b/src/navigator/providers/XmlParameterDefinitionProvider.ts
@@ -10,10 +10,9 @@ import { extractStatementParameterInfo } from '../parsers/parameterParser';
 import { extractStatementIdFromPosition } from '../parsers/xmlParser';
 import { extractXmlStatements } from '../parsers/xmlParser';
 import { extractMethodParameters } from '../parsers/javaParser';
-import { findJavaField } from '../parsers/javaFieldParser';
 import { isBuiltInType, isCollectionType } from '../../utils/javaTypeUtils';
 import { resolveFullyQualifiedType } from '../../utils/javaTypeResolver';
-import { findJavaClassFile } from '../../utils/navigationUtils';
+import { findFieldInHierarchy } from '../../utils/javaFieldHierarchy';
 
 /**
  * Provides go-to-definition for parameter references in XML SQL statements
@@ -120,7 +119,7 @@ export class XmlParameterDefinitionProvider implements vscode.DefinitionProvider
     }
 
     /**
-     * Find a field in a Java class by fully-qualified class name
+     * Find a field in a Java class (or one of its superclasses) by fully-qualified class name
      */
     private async findJavaFieldInClass(
         className: string,
@@ -131,25 +130,17 @@ export class XmlParameterDefinitionProvider implements vscode.DefinitionProvider
         }
 
         try {
-            const javaUri = await findJavaClassFile(className);
-            if (!javaUri) {
-                console.log(`[XmlParameterDefinitionProvider] Java class not found: ${className}`);
+            const resolved = await findFieldInHierarchy(className, fieldName);
+            if (!resolved) {
+                console.log(`[XmlParameterDefinitionProvider] Field ${fieldName} not found in class ${className} or its superclasses`);
                 return null;
             }
 
-            console.log(`[XmlParameterDefinitionProvider] Found Java class: ${javaUri.fsPath}`);
-
-            // Find the field in the class
-            const field = await findJavaField(javaUri.fsPath, fieldName);
-            if (field) {
-                return new vscode.Location(
-                    javaUri,
-                    new vscode.Position(field.line, field.startColumn)
-                );
-            }
-
-            console.log(`[XmlParameterDefinitionProvider] Field ${fieldName} not found in class ${className}`);
-            return null;
+            console.log(`[XmlParameterDefinitionProvider] Found field ${fieldName} in ${resolved.className}`);
+            return new vscode.Location(
+                vscode.Uri.file(resolved.filePath),
+                new vscode.Position(resolved.field.line, resolved.field.startColumn)
+            );
 
         } catch (error) {
             console.error('[XmlParameterDefinitionProvider] Error finding Java field:', error);

--- a/src/navigator/providers/XmlResultMapPropertyDefinitionProvider.ts
+++ b/src/navigator/providers/XmlResultMapPropertyDefinitionProvider.ts
@@ -5,8 +5,8 @@
 
 import * as vscode from 'vscode';
 import { isBuiltInTypeForNavigation as isBuiltInType } from '../../utils/javaTypeUtils';
-import { escapeRegex } from '../../utils/stringUtils';
-import { matchXmlAttributeAtCursor, mapCursorProportionally, findJavaClassFile, CursorMatchInfo } from '../../utils/navigationUtils';
+import { matchXmlAttributeAtCursor, mapCursorProportionally, CursorMatchInfo } from '../../utils/navigationUtils';
+import { findFieldInHierarchy } from '../../utils/javaFieldHierarchy';
 
 /**
  * Provides go-to-definition for property attributes in resultMap tags
@@ -95,7 +95,8 @@ export class XmlResultMapPropertyDefinitionProvider implements vscode.Definition
     }
 
     /**
-     * Find Java class and field by fully-qualified class name and field name
+     * Find Java class and field by fully-qualified class name and field name,
+     * searching superclasses when the field is inherited.
      * Maps cursor position proportionally from XML property to Java field
      */
     private async findJavaField(
@@ -110,75 +111,25 @@ export class XmlResultMapPropertyDefinitionProvider implements vscode.Definition
         }
 
         try {
-            const javaUri = await findJavaClassFile(className);
-            if (!javaUri) {
-                console.log(`[XmlResultMapPropertyDefinitionProvider] Java class not found: ${className}`);
+            const resolved = await findFieldInHierarchy(className, fieldName);
+            if (!resolved) {
+                console.log(`[XmlResultMapPropertyDefinitionProvider] Field ${fieldName} not found in class ${className} or its superclasses`);
                 return null;
             }
 
-            // Find the field declaration line
-            const document = await vscode.workspace.openTextDocument(javaUri);
-            const content = document.getText();
-            const lines = content.split('\n');
+            const { field } = resolved;
+            const sourceLength = matchInfo.endColumn - matchInfo.startColumn;
+            const targetLength = fieldName.length;
 
-            // Look for field declaration
-            const fieldRegex = new RegExp(
-                `(?:private|protected|public)?\\s+\\w+(?:<[^>]+>)?\\s+${escapeRegex(fieldName)}\\s*[;=]`
+            const targetColumn = (sourceLength > 0 && targetLength > 0)
+                ? mapCursorProportionally(matchInfo.cursorOffset, sourceLength, field.startColumn, targetLength)
+                : field.startColumn;
+
+            console.log(`[XmlResultMapPropertyDefinitionProvider] Field position: ${resolved.filePath} line ${field.line}, column ${targetColumn}`);
+            return new vscode.Location(
+                vscode.Uri.file(resolved.filePath),
+                new vscode.Position(field.line, targetColumn)
             );
-
-            // Track if we're in a class body
-            let inClassBody = false;
-            let braceLevel = 0;
-
-            for (let i = 0; i < lines.length; i++) {
-                const line = lines[i];
-                const trimmedLine = line.trim();
-
-                // Track class boundaries
-                if (/(?:class|interface|enum)\s+\w+/.test(line)) {
-                    inClassBody = false;
-                }
-
-                // Track brace level
-                braceLevel += (line.match(/{/g) || []).length;
-                braceLevel -= (line.match(/}/g) || []).length;
-
-                if (braceLevel > 0) {
-                    inClassBody = true;
-                }
-
-                if (!inClassBody || braceLevel < 1) {
-                    continue;
-                }
-
-                // Try to match field on current line
-                if (fieldRegex.test(trimmedLine)) {
-                    console.log(`[XmlResultMapPropertyDefinitionProvider] Found field at line ${i}`);
-
-                    // Find the exact column position of the field name
-                    const fieldNameRegex = new RegExp(`\\b${escapeRegex(fieldName)}\\b`);
-                    const match = line.match(fieldNameRegex);
-
-                    if (match && match.index !== undefined) {
-                        const fieldStartColumn = match.index;
-                        const sourceLength = matchInfo.endColumn - matchInfo.startColumn;
-                        const targetLength = fieldName.length;
-
-                        const targetColumn = (sourceLength > 0 && targetLength > 0)
-                            ? mapCursorProportionally(matchInfo.cursorOffset, sourceLength, fieldStartColumn, targetLength)
-                            : fieldStartColumn;
-
-                        console.log(`[XmlResultMapPropertyDefinitionProvider] Field position: line ${i}, column ${targetColumn}`);
-                        return new vscode.Location(javaUri, new vscode.Position(i, targetColumn));
-                    }
-
-                    // Fallback to line start
-                    return new vscode.Location(javaUri, new vscode.Position(i, 0));
-                }
-            }
-
-            console.log(`[XmlResultMapPropertyDefinitionProvider] Field ${fieldName} not found in class`);
-            return null;
 
         } catch (error) {
             console.error('[XmlResultMapPropertyDefinitionProvider] Error finding Java field:', error);

--- a/src/test/fixtures/parameter-validation/AuditEntity.java
+++ b/src/test/fixtures/parameter-validation/AuditEntity.java
@@ -1,0 +1,15 @@
+package com.example.audit;
+
+import com.example.entity.BaseEntity;
+
+public class AuditEntity extends BaseEntity<Long> {
+    private String updatedBy;
+
+    public String getUpdatedBy() {
+        return updatedBy;
+    }
+
+    public void setUpdatedBy(String updatedBy) {
+        this.updatedBy = updatedBy;
+    }
+}

--- a/src/test/fixtures/parameter-validation/AuditEntity.java
+++ b/src/test/fixtures/parameter-validation/AuditEntity.java
@@ -4,6 +4,7 @@ import com.example.entity.BaseEntity;
 
 public class AuditEntity extends BaseEntity<Long> {
     private String updatedBy;
+    private String shadowedField;
 
     public String getUpdatedBy() {
         return updatedBy;

--- a/src/test/fixtures/parameter-validation/BaseEntity.java
+++ b/src/test/fixtures/parameter-validation/BaseEntity.java
@@ -5,6 +5,7 @@ public class BaseEntity<ID> {
     private String createdBy;
     private String createTime;
     @Deprecated private String astOnlyField;
+    private String shadowedField;
 
     public ID getId() {
         return id;

--- a/src/test/fixtures/parameter-validation/BaseEntity.java
+++ b/src/test/fixtures/parameter-validation/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.example.entity;
+
+public class BaseEntity<ID> {
+    private ID id;
+    private String createdBy;
+    private String createTime;
+
+    public ID getId() {
+        return id;
+    }
+
+    public void setId(ID id) {
+        this.id = id;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public String getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(String createTime) {
+        this.createTime = createTime;
+    }
+}

--- a/src/test/fixtures/parameter-validation/BaseEntity.java
+++ b/src/test/fixtures/parameter-validation/BaseEntity.java
@@ -4,6 +4,7 @@ public class BaseEntity<ID> {
     private ID id;
     private String createdBy;
     private String createTime;
+    @Deprecated private String astOnlyField;
 
     public ID getId() {
         return id;

--- a/src/test/fixtures/parameter-validation/TaskMapper.java
+++ b/src/test/fixtures/parameter-validation/TaskMapper.java
@@ -1,0 +1,19 @@
+package com.example.mapper;
+
+import com.example.query.TaskQuery;
+import org.apache.ibatis.annotations.Mapper;
+import java.util.List;
+
+@Mapper
+public interface TaskMapper {
+    /**
+     * Single object parameter auto-mapping with inherited fields
+     * TaskQuery extends AuditEntity extends BaseEntity<Long>
+     */
+    List<TaskQuery> selectByCondition(TaskQuery condition);
+
+    /**
+     * parameterType with inherited fields
+     */
+    int countByCondition(TaskQuery condition);
+}

--- a/src/test/fixtures/parameter-validation/TaskMapper.xml
+++ b/src/test/fixtures/parameter-validation/TaskMapper.xml
@@ -9,6 +9,7 @@
         <result property="updatedBy" column="updated_by"/>
         <result property="taskName" column="task_name"/>
         <result property="astOnlyField" column="ast_only_field"/>
+        <result property="shadowedField" column="shadowed_field"/>
     </resultMap>
 
     <!--
@@ -21,6 +22,12 @@
     <select id="selectByCondition" resultMap="TaskResultMap">
         SELECT * FROM t_task
         <where>
+            <if test="shadowedField != null">
+                AND shadowed_field = #{shadowedField}
+            </if>
+            <if test="astOnlyField != null">
+                AND ast_only_field = #{astOnlyField}
+            </if>
             <if test="taskName != null">
                 AND task_name = #{taskName}
             </if>
@@ -35,9 +42,6 @@
             </if>
             <if test="id != null">
                 AND id = #{id}
-            </if>
-            <if test="astOnlyField != null">
-                AND ast_only_field = #{astOnlyField}
             </if>
         </where>
     </select>

--- a/src/test/fixtures/parameter-validation/TaskMapper.xml
+++ b/src/test/fixtures/parameter-validation/TaskMapper.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.mapper.TaskMapper">
+
+    <resultMap id="TaskResultMap" type="com.example.query.TaskQuery">
+        <id property="id" column="id"/>
+        <result property="createdBy" column="created_by"/>
+        <result property="updatedBy" column="updated_by"/>
+        <result property="taskName" column="task_name"/>
+    </resultMap>
+
+    <!--
+        Inherited field validation (issue #50):
+        - taskName, status are declared on TaskQuery itself
+        - updatedBy is inherited from AuditEntity
+        - createdBy, id are inherited from BaseEntity<Long> (two levels up)
+        None of these should show parameter validation errors
+    -->
+    <select id="selectByCondition" resultMap="TaskResultMap">
+        SELECT * FROM t_task
+        <where>
+            <if test="taskName != null">
+                AND task_name = #{taskName}
+            </if>
+            <if test="status != null">
+                AND status = #{status}
+            </if>
+            <if test="updatedBy != null">
+                AND updated_by = #{updatedBy}
+            </if>
+            <if test="createdBy != null">
+                AND created_by = #{createdBy}
+            </if>
+            <if test="id != null">
+                AND id = #{id}
+            </if>
+        </where>
+    </select>
+
+    <!--
+        parameterType path with inherited fields.
+        createdBy is inherited and must be valid;
+        nonExistentField must still be flagged as undefined
+    -->
+    <select id="countByCondition" parameterType="com.example.query.TaskQuery" resultType="int">
+        SELECT COUNT(*) FROM t_task
+        WHERE created_by = #{createdBy}
+        AND missing_col = #{nonExistentField}
+    </select>
+
+</mapper>

--- a/src/test/fixtures/parameter-validation/TaskMapper.xml
+++ b/src/test/fixtures/parameter-validation/TaskMapper.xml
@@ -8,13 +8,14 @@
         <result property="createdBy" column="created_by"/>
         <result property="updatedBy" column="updated_by"/>
         <result property="taskName" column="task_name"/>
+        <result property="astOnlyField" column="ast_only_field"/>
     </resultMap>
 
     <!--
         Inherited field validation (issue #50):
         - taskName, status are declared on TaskQuery itself
         - updatedBy is inherited from AuditEntity
-        - createdBy, id are inherited from BaseEntity<Long> (two levels up)
+        - createdBy, id, astOnlyField are inherited from BaseEntity<Long> (two levels up)
         None of these should show parameter validation errors
     -->
     <select id="selectByCondition" resultMap="TaskResultMap">
@@ -34,6 +35,9 @@
             </if>
             <if test="id != null">
                 AND id = #{id}
+            </if>
+            <if test="astOnlyField != null">
+                AND ast_only_field = #{astOnlyField}
             </if>
         </where>
     </select>

--- a/src/test/fixtures/parameter-validation/TaskQuery.java
+++ b/src/test/fixtures/parameter-validation/TaskQuery.java
@@ -1,0 +1,24 @@
+package com.example.query;
+
+import com.example.audit.AuditEntity;
+
+public class TaskQuery extends AuditEntity {
+    private String taskName;
+    private Integer status;
+
+    public String getTaskName() {
+        return taskName;
+    }
+
+    public void setTaskName(String taskName) {
+        this.taskName = taskName;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+}

--- a/src/test/integration/definitionProviders.test.ts
+++ b/src/test/integration/definitionProviders.test.ts
@@ -16,6 +16,7 @@ suite('Definition Providers Integration Tests', () => {
     let userMapperJavaPath: string;
     let userMapperXmlPath: string;
     let extensionPath: string;
+    let originalUseDefinitionProvider: boolean | undefined;
 
     suiteSetup(async function() {
         // This may take time as it initializes the extension
@@ -43,16 +44,24 @@ suite('Definition Providers Integration Tests', () => {
         // Initialize FileMapper
         fileMapper = new FileMapper(context, 1000);
         await fileMapper.initialize();
+
+        // Java→XML F12 navigation is only registered in DefinitionProvider mode.
+        const config = vscode.workspace.getConfiguration('mybatis-boost');
+        originalUseDefinitionProvider = config.inspect<boolean>('useDefinitionProvider')?.workspaceValue;
+        await config.update('useDefinitionProvider', true, vscode.ConfigurationTarget.Workspace);
     });
 
-    suiteTeardown(() => {
+    suiteTeardown(async () => {
+        await vscode.workspace
+            .getConfiguration('mybatis-boost')
+            .update('useDefinitionProvider', originalUseDefinitionProvider, vscode.ConfigurationTarget.Workspace);
+
         if (fileMapper) {
             fileMapper.dispose();
         }
     });
 
-    // Java→XML DefinitionProvider is only registered when useDefinitionProvider=true (default uses CodeLens)
-    suite.skip('Java to XML Navigation', () => {
+    suite('Java to XML Navigation', () => {
         test('should navigate from Java method to XML statement', async function() {
             this.timeout(10000);
 

--- a/src/test/integration/parameterValidator.inheritedFields.test.ts
+++ b/src/test/integration/parameterValidator.inheritedFields.test.ts
@@ -66,6 +66,8 @@ suite('ParameterValidator - Inherited Fields Integration Tests', () => {
         // - #{updatedBy}             (inherited from AuditEntity)
         // - #{createdBy}, #{id}, #{astOnlyField}
         //                             (inherited from BaseEntity<Long>, two levels up)
+        // - #{shadowedField}          (declared in both AuditEntity and BaseEntity;
+        //                              the nearer AuditEntity declaration wins)
         // - #{nonExistentField}      (invalid on purpose)
         // Only nonExistentField may be flagged.
         const unexpectedDiagnostics = mybatisDiagnostics.filter(

--- a/src/test/integration/parameterValidator.inheritedFields.test.ts
+++ b/src/test/integration/parameterValidator.inheritedFields.test.ts
@@ -64,7 +64,8 @@ suite('ParameterValidator - Inherited Fields Integration Tests', () => {
         // The document references:
         // - #{taskName}, #{status}   (declared on TaskQuery itself)
         // - #{updatedBy}             (inherited from AuditEntity)
-        // - #{createdBy}, #{id}      (inherited from BaseEntity<Long>, two levels up)
+        // - #{createdBy}, #{id}, #{astOnlyField}
+        //                             (inherited from BaseEntity<Long>, two levels up)
         // - #{nonExistentField}      (invalid on purpose)
         // Only nonExistentField may be flagged.
         const unexpectedDiagnostics = mybatisDiagnostics.filter(

--- a/src/test/integration/parameterValidator.inheritedFields.test.ts
+++ b/src/test/integration/parameterValidator.inheritedFields.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Integration tests for ParameterValidator - inherited fields (issue #50)
+ *
+ * TaskQuery extends AuditEntity extends BaseEntity<Long>, so parameters that
+ * reference inherited fields must not be reported as undefined.
+ */
+
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { ParameterValidator } from '../../navigator/diagnostics/ParameterValidator';
+import { FileMapper } from '../../navigator/core/FileMapper';
+import { createMockContext } from '../helpers/testSetup';
+
+suite('ParameterValidator - Inherited Fields Integration Tests', () => {
+    let parameterValidator: ParameterValidator;
+    let fileMapper: FileMapper;
+    let context: vscode.ExtensionContext;
+    let extensionPath: string;
+
+    suiteSetup(async function() {
+        this.timeout(30000);
+
+        extensionPath = vscode.extensions.getExtension('young1lin.mybatis-boost')?.extensionPath || process.cwd();
+        context = createMockContext(extensionPath);
+
+        fileMapper = new FileMapper(context, 5000);
+        await fileMapper.initialize();
+
+        parameterValidator = new ParameterValidator(context, fileMapper);
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    });
+
+    suiteTeardown(() => {
+        if (parameterValidator) {
+            parameterValidator.dispose();
+        }
+        if (fileMapper) {
+            fileMapper.dispose();
+        }
+    });
+
+    test('should accept parameters that reference inherited fields', async function() {
+        this.timeout(10000);
+
+        const xmlPath = path.join(
+            extensionPath,
+            'src', 'test', 'fixtures', 'parameter-validation',
+            'TaskMapper.xml'
+        );
+
+        const xmlUri = vscode.Uri.file(xmlPath);
+        const document = await vscode.workspace.openTextDocument(xmlUri);
+
+        await parameterValidator.validateDocument(document);
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        const diagnostics = vscode.languages.getDiagnostics(xmlUri);
+        const mybatisDiagnostics = diagnostics.filter(d => d.source === 'MyBatis Boost');
+
+        console.log(`[Test] All diagnostics: ${JSON.stringify(mybatisDiagnostics.map(d => ({ message: d.message, line: d.range.start.line })))}`);
+
+        // The document references:
+        // - #{taskName}, #{status}   (declared on TaskQuery itself)
+        // - #{updatedBy}             (inherited from AuditEntity)
+        // - #{createdBy}, #{id}      (inherited from BaseEntity<Long>, two levels up)
+        // - #{nonExistentField}      (invalid on purpose)
+        // Only nonExistentField may be flagged.
+        const unexpectedDiagnostics = mybatisDiagnostics.filter(
+            d => !d.message.includes('nonExistentField')
+        );
+
+        assert.strictEqual(
+            unexpectedDiagnostics.length,
+            0,
+            `Inherited fields should not be reported as undefined, but got: ${unexpectedDiagnostics.map(d => `${d.message} at line ${d.range.start.line}`).join('; ')}`
+        );
+    });
+
+    test('should still flag parameters that exist nowhere in the hierarchy', async function() {
+        this.timeout(10000);
+
+        const xmlPath = path.join(
+            extensionPath,
+            'src', 'test', 'fixtures', 'parameter-validation',
+            'TaskMapper.xml'
+        );
+
+        const xmlUri = vscode.Uri.file(xmlPath);
+        const document = await vscode.workspace.openTextDocument(xmlUri);
+
+        await parameterValidator.validateDocument(document);
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        const diagnostics = vscode.languages.getDiagnostics(xmlUri);
+        const nonExistentDiagnostics = diagnostics.filter(
+            d => d.source === 'MyBatis Boost' && d.message.includes('nonExistentField')
+        );
+
+        console.log(`[Test] nonExistentField diagnostics: ${JSON.stringify(nonExistentDiagnostics.map(d => d.message))}`);
+
+        assert.ok(
+            nonExistentDiagnostics.length >= 1,
+            'Parameter that exists neither on the class nor its superclasses must be flagged'
+        );
+    });
+});

--- a/src/test/integration/preciseNavigation.test.ts
+++ b/src/test/integration/preciseNavigation.test.ts
@@ -7,11 +7,9 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as os from 'os';
 import { FileMapper, JavaToXmlDefinitionProvider, XmlToJavaDefinitionProvider, XmlSqlFragmentDefinitionProvider } from '../../navigator';
 
-// Skip: tests create temp files outside workspace, executeDefinitionProvider requires workspace-scoped FileMapper
-suite.skip('Precise Position Navigation Integration Tests', () => {
+suite('Precise Position Navigation Integration Tests', () => {
     let tempDir: string;
     let javaFilePath: string;
     let xmlFilePath: string;
@@ -23,8 +21,10 @@ suite.skip('Precise Position Navigation Integration Tests', () => {
     suiteSetup(async function() {
         this.timeout(30000);
 
-        // Create temporary directory for test files
-        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mybatis-boost-test-'));
+        // FileMapper intentionally limits lookup to the open workspace.
+        const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        assert.ok(workspaceRoot, 'Workspace root is required');
+        tempDir = fs.mkdtempSync(path.join(workspaceRoot, '.mybatis-boost-test-'));
 
         // Create directory structure
         const javaDir = path.join(tempDir, 'src', 'main', 'java', 'com', 'example', 'mapper');
@@ -357,7 +357,7 @@ public interface TestMapper {
             const includePattern = /<include refid="BaseColumns"/;
             assert.ok(includePattern.test(xmlContent), 'include refid="BaseColumns" not found in XML');
 
-            const includeRefIdIndex = xmlContent.indexOf('"BaseColumns"') + 1; // Position at 'B'
+            const includeRefIdIndex = xmlContent.indexOf('<include refid="BaseColumns"') + '<include refid="'.length; // Position at 'B'
             const cursorOffset = 4; // Position at 'C' in "BaseColumns"
             const position = xmlDoc.positionAt(includeRefIdIndex + cursorOffset);
 
@@ -414,7 +414,7 @@ public interface TestMapper {
             const includePattern = /<include refid="UserColumns"/;
             assert.ok(includePattern.test(xmlContent), 'include refid="UserColumns" not found in XML');
 
-            const includeRefIdIndex = xmlContent.indexOf('"UserColumns"') + 1; // Position at 'U'
+            const includeRefIdIndex = xmlContent.indexOf('<include refid="UserColumns"') + '<include refid="'.length; // Position at 'U'
             const userColumnsLength = 'UserColumns'.length;
             const cursorOffset = userColumnsLength - 1; // Position at last 's'
             const position = xmlDoc.positionAt(includeRefIdIndex + cursorOffset);
@@ -465,7 +465,7 @@ public interface TestMapper {
             const xmlContent = xmlDoc.getText();
 
             // Test cursor at the very start of "BaseColumns" (at 'B')
-            const includeRefIdIndex = xmlContent.indexOf('"BaseColumns"') + 1; // Position at 'B'
+            const includeRefIdIndex = xmlContent.indexOf('<include refid="BaseColumns"') + '<include refid="'.length; // Position at 'B'
             const position = xmlDoc.positionAt(includeRefIdIndex);
 
             console.log('Testing navigation from include refid at start position');

--- a/src/test/integration/xmlParameterNavigation.inheritedFields.test.ts
+++ b/src/test/integration/xmlParameterNavigation.inheritedFields.test.ts
@@ -107,4 +107,20 @@ suite('XML Parameter Navigation - Inherited Fields', () => {
         assert.strictEqual(definitions[0].range.start.line, 6,
             'Should point to the annotated astOnlyField declaration in BaseEntity');
     });
+
+    test('should navigate to the nearest declaration when a superclass field is shadowed', async function() {
+        this.timeout(10000);
+
+        // Both AuditEntity and BaseEntity declare shadowedField. TaskQuery
+        // inherits through AuditEntity, so navigation must stop at that nearer
+        // declaration instead of continuing to BaseEntity.
+        const offset = await findOffset(/#\{shadowedField\}/, 2);
+        const definitions = await executeDefinitionAt(offset);
+
+        assert.ok(definitions.length > 0, 'No definitions found for #{shadowedField}');
+        assert.ok(definitions[0].uri.fsPath.endsWith('AuditEntity.java'),
+            `Expected AuditEntity.java, got ${definitions[0].uri.fsPath}`);
+        assert.strictEqual(definitions[0].range.start.line, 6,
+            'Should point to the nearer shadowedField declaration in AuditEntity');
+    });
 });

--- a/src/test/integration/xmlParameterNavigation.inheritedFields.test.ts
+++ b/src/test/integration/xmlParameterNavigation.inheritedFields.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Integration tests for XML → Java field navigation with inherited fields (issue #50)
+ *
+ * TaskQuery extends AuditEntity extends BaseEntity<Long>. Navigation from
+ * #{param} references and resultMap property attributes must land in the
+ * file that actually declares the field, walking superclasses when needed.
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+suite('XML Parameter Navigation - Inherited Fields', () => {
+    let fixtureRoot: string;
+    let xmlPath: string;
+
+    suiteSetup(async function() {
+        this.timeout(30000);
+
+        const extensionPath = vscode.extensions.getExtension('young1lin.mybatis-boost')?.extensionPath || process.cwd();
+        fixtureRoot = path.join(extensionPath, 'src', 'test', 'fixtures', 'parameter-validation');
+        xmlPath = path.join(fixtureRoot, 'TaskMapper.xml');
+    });
+
+    async function executeDefinitionAt(offset: number): Promise<vscode.Location[]> {
+        const xmlDoc = await vscode.workspace.openTextDocument(xmlPath);
+        await vscode.window.showTextDocument(xmlDoc);
+        const position = xmlDoc.positionAt(offset);
+
+        const definitions = await vscode.commands.executeCommand<vscode.Location[]>(
+            'vscode.executeDefinitionProvider',
+            xmlDoc.uri,
+            position
+        );
+        return definitions || [];
+    }
+
+    async function findOffset(pattern: RegExp, skip: number): Promise<number> {
+        const xmlDoc = await vscode.workspace.openTextDocument(xmlPath);
+        const match = xmlDoc.getText().match(pattern);
+        assert.ok(match && match.index !== undefined, `${pattern} not found in TaskMapper.xml`);
+        return match.index + skip;
+    }
+
+    test('should navigate from #{taskName} to the field declared on TaskQuery itself', async function() {
+        this.timeout(10000);
+
+        const offset = await findOffset(/#\{taskName\}/, 2);
+        const definitions = await executeDefinitionAt(offset);
+
+        assert.ok(definitions.length > 0, 'No definitions found for #{taskName}');
+        assert.ok(definitions[0].uri.fsPath.endsWith('TaskQuery.java'),
+            `Expected TaskQuery.java, got ${definitions[0].uri.fsPath}`);
+    });
+
+    test('should navigate from #{updatedBy} to the inherited field in AuditEntity', async function() {
+        this.timeout(10000);
+
+        const offset = await findOffset(/#\{updatedBy\}/, 2);
+        const definitions = await executeDefinitionAt(offset);
+
+        assert.ok(definitions.length > 0, 'No definitions found for #{updatedBy}');
+        assert.ok(definitions[0].uri.fsPath.endsWith('AuditEntity.java'),
+            `Expected AuditEntity.java, got ${definitions[0].uri.fsPath}`);
+        assert.strictEqual(definitions[0].range.start.line, 5,
+            'Should point to the updatedBy declaration in AuditEntity');
+    });
+
+    test('should navigate from #{createdBy} to the field inherited from BaseEntity two levels up', async function() {
+        this.timeout(10000);
+
+        const offset = await findOffset(/#\{createdBy\}/, 2);
+        const definitions = await executeDefinitionAt(offset);
+
+        assert.ok(definitions.length > 0, 'No definitions found for #{createdBy}');
+        assert.ok(definitions[0].uri.fsPath.endsWith('BaseEntity.java'),
+            `Expected BaseEntity.java, got ${definitions[0].uri.fsPath}`);
+        assert.strictEqual(definitions[0].range.start.line, 4,
+            'Should point to the createdBy declaration in BaseEntity');
+    });
+
+    test('should navigate from resultMap property="createdBy" to the inherited field in BaseEntity', async function() {
+        this.timeout(10000);
+
+        // Cursor inside the attribute value of <result property="createdBy" .../>
+        const offset = await findOffset(/property="createdBy"/, 'property="'.length);
+        const definitions = await executeDefinitionAt(offset);
+
+        assert.ok(definitions.length > 0, 'No definitions found for property="createdBy"');
+        assert.ok(definitions[0].uri.fsPath.endsWith('BaseEntity.java'),
+            `Expected BaseEntity.java, got ${definitions[0].uri.fsPath}`);
+        assert.strictEqual(definitions[0].range.start.line, 4,
+            'Should point to the createdBy declaration in BaseEntity');
+    });
+});

--- a/src/test/integration/xmlParameterNavigation.inheritedFields.test.ts
+++ b/src/test/integration/xmlParameterNavigation.inheritedFields.test.ts
@@ -92,4 +92,19 @@ suite('XML Parameter Navigation - Inherited Fields', () => {
         assert.strictEqual(definitions[0].range.start.line, 4,
             'Should point to the createdBy declaration in BaseEntity');
     });
+
+    test('should use the bundled AST parser for an annotated inherited field', async function() {
+        this.timeout(10000);
+
+        // The regex fallback skips lines beginning with annotations, so this
+        // definition is available only when tree-sitter initializes in dist.
+        const offset = await findOffset(/#\{astOnlyField\}/, 2);
+        const definitions = await executeDefinitionAt(offset);
+
+        assert.ok(definitions.length > 0, 'No definitions found for #{astOnlyField}');
+        assert.ok(definitions[0].uri.fsPath.endsWith('BaseEntity.java'),
+            `Expected BaseEntity.java, got ${definitions[0].uri.fsPath}`);
+        assert.strictEqual(definitions[0].range.start.line, 6,
+            'Should point to the annotated astOnlyField declaration in BaseEntity');
+    });
 });

--- a/src/test/unit/LRUCache.test.ts
+++ b/src/test/unit/LRUCache.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for LRUCache, including the eviction callback used by
+ * ParameterValidator to keep dependency bookkeeping in sync with the cache.
+ */
+
+import * as assert from 'assert';
+import { LRUCache } from '../../utils/LRUCache';
+
+describe('LRUCache Unit Tests', () => {
+    it('should evict the least recently used entry when full', () => {
+        const cache = new LRUCache<string, number>(2);
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.set('c', 3);
+
+        assert.strictEqual(cache.has('a'), false);
+        assert.strictEqual(cache.get('b'), 2);
+        assert.strictEqual(cache.get('c'), 3);
+        assert.strictEqual(cache.size(), 2);
+    });
+
+    it('should refresh recency on get', () => {
+        const cache = new LRUCache<string, number>(2);
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.get('a');
+        cache.set('c', 3);
+
+        assert.strictEqual(cache.has('a'), true, 'recently read entry should survive');
+        assert.strictEqual(cache.has('b'), false, 'stale entry should be evicted');
+    });
+
+    describe('onEvict callback', () => {
+        it('should fire with the evicted key and value on capacity eviction', () => {
+            const evicted: Array<{ key: string; value: number }> = [];
+            const cache = new LRUCache<string, number>(2, (key, value) => evicted.push({ key, value }));
+
+            cache.set('a', 1);
+            cache.set('b', 2);
+            cache.set('c', 3);
+
+            assert.deepStrictEqual(evicted, [{ key: 'a', value: 1 }]);
+        });
+
+        it('should not fire when updating an existing key', () => {
+            const evicted: string[] = [];
+            const cache = new LRUCache<string, number>(2, key => evicted.push(key));
+
+            cache.set('a', 1);
+            cache.set('b', 2);
+            cache.set('a', 10);
+
+            assert.deepStrictEqual(evicted, []);
+            assert.strictEqual(cache.get('a'), 10);
+        });
+
+        it('should not fire on explicit delete or clear', () => {
+            const evicted: string[] = [];
+            const cache = new LRUCache<string, number>(2, key => evicted.push(key));
+
+            cache.set('a', 1);
+            cache.set('b', 2);
+            cache.delete('a');
+            cache.clear();
+
+            assert.deepStrictEqual(evicted, []);
+        });
+    });
+});

--- a/src/test/unit/ParameterValidator.inheritanceCache.test.ts
+++ b/src/test/unit/ParameterValidator.inheritanceCache.test.ts
@@ -7,6 +7,7 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import * as vscode from 'vscode';
 import { ParameterValidator } from '../../navigator/diagnostics/ParameterValidator';
 import * as javaFieldHierarchy from '../../utils/javaFieldHierarchy';
 
@@ -100,5 +101,34 @@ describe('ParameterValidator Inherited Field Caching', () => {
         await validator.getClassFields(CHILD_FQN);
 
         assert.strictEqual(walkerStub.callCount, 3);
+    });
+
+    it('should revalidate open XML documents when a Java file is saved', () => {
+        const saveHandlers: ((doc: unknown) => void)[] = [];
+        const originalOnSave = vscode.workspace.onDidSaveTextDocument;
+        (vscode.workspace as any).onDidSaveTextDocument = (callback: (doc: unknown) => void) => {
+            saveHandlers.push(callback);
+            return { dispose: () => {} };
+        };
+
+        try {
+            const mockContext = { subscriptions: { push: () => {} } };
+            const mockFileMapper = { getJavaPath: () => Promise.resolve(null) };
+            const localValidator: any = new ParameterValidator(mockContext as any, mockFileMapper as any);
+
+            const revalidateSpy = sinon.spy(localValidator, 'revalidateOpenXmlDocuments');
+
+            saveHandlers.forEach(handler => handler({
+                languageId: 'java',
+                uri: { fsPath: '/project/src/main/java/com/example/entity/BaseEntity.java' }
+            }));
+
+            assert.ok(revalidateSpy.called,
+                'Saving a Java file must trigger revalidation of open XML documents');
+
+            localValidator.dispose();
+        } finally {
+            (vscode.workspace as any).onDidSaveTextDocument = originalOnSave;
+        }
     });
 });

--- a/src/test/unit/ParameterValidator.inheritanceCache.test.ts
+++ b/src/test/unit/ParameterValidator.inheritanceCache.test.ts
@@ -120,6 +120,43 @@ describe('ParameterValidator Inherited Field Caching', () => {
             'evicted key must leave dependent sets');
     });
 
+    it('should not keep links from a superseded chain when overlapping misses repopulate the same key', async () => {
+        // Two concurrent cache misses for the same FQN: the first walk still
+        // sees the parent, the second (later) walk does not
+        walkerStub.onFirstCall().resolves({
+            fields: [
+                {
+                    field: { name: 'taskName', fieldType: 'String', line: 5, startColumn: 19, endColumn: 27 },
+                    filePath: '/fake/TaskQuery.java',
+                    className: CHILD_FQN
+                }
+            ],
+            classChain: [CHILD_FQN, PARENT_FQN]
+        });
+        walkerStub.onSecondCall().resolves({
+            fields: [
+                {
+                    field: { name: 'taskName', fieldType: 'String', line: 5, startColumn: 19, endColumn: 27 },
+                    filePath: '/fake/TaskQuery.java',
+                    className: CHILD_FQN
+                }
+            ],
+            classChain: [CHILD_FQN]
+        });
+
+        // Start both before either resolves so both miss the cache
+        await Promise.all([
+            validator.getClassFields(CHILD_FQN),
+            validator.getClassFields(CHILD_FQN)
+        ]);
+
+        assert.strictEqual(walkerStub.callCount, 2, 'both overlapping calls should have walked');
+        assert.deepStrictEqual(validator.dependencyChains.get(CHILD_FQN), [CHILD_FQN],
+            'forward index must hold the latest chain');
+        assert.ok(!validator.classDependents.get(PARENT_FQN)?.has(CHILD_FQN),
+            'links from the superseded chain must be dropped');
+    });
+
     it('should re-register hierarchy dependents after re-walking', async () => {
         await validator.getClassFields(CHILD_FQN);
 

--- a/src/test/unit/ParameterValidator.inheritanceCache.test.ts
+++ b/src/test/unit/ParameterValidator.inheritanceCache.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for ParameterValidator field caching with inherited fields (issue #50)
+ *
+ * Verifies that getClassFields resolves fields through the class hierarchy walker
+ * and that editing a superclass invalidates cached entries of its subclasses.
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { ParameterValidator } from '../../navigator/diagnostics/ParameterValidator';
+import * as javaFieldHierarchy from '../../utils/javaFieldHierarchy';
+
+describe('ParameterValidator Inherited Field Caching', () => {
+    const CHILD_FQN = 'com.example.query.TaskQuery';
+    const PARENT_FQN = 'com.example.entity.BaseEntity';
+
+    let walkerStub: sinon.SinonStub;
+    // Typed as any to reach the private getClassFields/invalidateFieldCache under test
+    let validator: any;
+
+    beforeEach(() => {
+        walkerStub = sinon.stub(javaFieldHierarchy, 'getClassFieldsWithInheritance').resolves({
+            fields: [
+                {
+                    field: { name: 'taskName', fieldType: 'String', line: 5, startColumn: 19, endColumn: 27 },
+                    filePath: '/fake/TaskQuery.java',
+                    className: CHILD_FQN
+                },
+                {
+                    field: { name: 'createdBy', fieldType: 'String', line: 4, startColumn: 19, endColumn: 28 },
+                    filePath: '/fake/BaseEntity.java',
+                    className: PARENT_FQN
+                }
+            ],
+            classChain: [CHILD_FQN, PARENT_FQN]
+        });
+
+        const mockContext = {
+            subscriptions: { push: () => {} }
+        };
+        const mockFileMapper = {
+            getJavaPath: () => Promise.resolve(null)
+        };
+
+        validator = new ParameterValidator(mockContext as any, mockFileMapper as any);
+    });
+
+    afterEach(() => {
+        validator.dispose();
+        sinon.restore();
+    });
+
+    it('should return own and inherited field names', async () => {
+        const fields = await validator.getClassFields(CHILD_FQN);
+        assert.deepStrictEqual(fields, ['taskName', 'createdBy']);
+    });
+
+    it('should cache results per class', async () => {
+        await validator.getClassFields(CHILD_FQN);
+        await validator.getClassFields(CHILD_FQN);
+        assert.strictEqual(walkerStub.callCount, 1, 'Second call should hit the cache');
+    });
+
+    it('should invalidate the cached entry when the subclass file changes', async () => {
+        await validator.getClassFields(CHILD_FQN);
+
+        validator.invalidateFieldCache('/project/src/main/java/com/example/query/TaskQuery.java');
+
+        await validator.getClassFields(CHILD_FQN);
+        assert.strictEqual(walkerStub.callCount, 2, 'Cache entry should be gone after subclass edit');
+    });
+
+    it('should invalidate the subclass cached entry when a superclass file changes', async () => {
+        await validator.getClassFields(CHILD_FQN);
+
+        validator.invalidateFieldCache('/project/src/main/java/com/example/entity/BaseEntity.java');
+
+        await validator.getClassFields(CHILD_FQN);
+        assert.strictEqual(walkerStub.callCount, 2, 'Superclass edit should invalidate the subclass entry');
+    });
+
+    it('should keep the cached entry when an unrelated class changes', async () => {
+        await validator.getClassFields(CHILD_FQN);
+
+        validator.invalidateFieldCache('/project/src/main/java/com/example/Other.java');
+
+        await validator.getClassFields(CHILD_FQN);
+        assert.strictEqual(walkerStub.callCount, 1, 'Unrelated edit should not invalidate the entry');
+    });
+
+    it('should re-register hierarchy dependents after re-walking', async () => {
+        await validator.getClassFields(CHILD_FQN);
+
+        // First parent edit invalidates; re-walk must register dependents again
+        validator.invalidateFieldCache('/project/src/main/java/com/example/entity/BaseEntity.java');
+        await validator.getClassFields(CHILD_FQN);
+
+        // Second parent edit must invalidate again
+        validator.invalidateFieldCache('/project/src/main/java/com/example/entity/BaseEntity.java');
+        await validator.getClassFields(CHILD_FQN);
+
+        assert.strictEqual(walkerStub.callCount, 3);
+    });
+});

--- a/src/test/unit/ParameterValidator.inheritanceCache.test.ts
+++ b/src/test/unit/ParameterValidator.inheritanceCache.test.ts
@@ -89,6 +89,37 @@ describe('ParameterValidator Inherited Field Caching', () => {
         assert.strictEqual(walkerStub.callCount, 1, 'Unrelated edit should not invalidate the entry');
     });
 
+    it('should fully prune dependency bookkeeping when an entry is invalidated', async () => {
+        await validator.getClassFields(CHILD_FQN);
+
+        assert.strictEqual(validator.dependencyChains.size, 1, 'chain should be registered');
+        assert.ok(validator.classDependents.get(PARENT_FQN)?.has(CHILD_FQN));
+
+        validator.invalidateFieldCache('/project/src/main/java/com/example/query/TaskQuery.java');
+
+        assert.strictEqual(validator.dependencyChains.size, 0,
+            'forward index must not retain invalidated keys');
+        assert.strictEqual(validator.classDependents.size, 0,
+            'dependent sets must not retain invalidated keys');
+    });
+
+    it('should prune dependency bookkeeping when the cache silently evicts an entry', async () => {
+        await validator.getClassFields(CHILD_FQN);
+        assert.ok(validator.dependencyChains.has(CHILD_FQN));
+
+        // Fill the cache past its capacity (200) so the first entry is evicted
+        for (let i = 0; i < 200; i++) {
+            await validator.getClassFields(`com.example.Filler${i}`);
+        }
+
+        assert.strictEqual(validator.fieldCache.has(CHILD_FQN), false,
+            'oldest entry should have been evicted');
+        assert.strictEqual(validator.dependencyChains.has(CHILD_FQN), false,
+            'evicted key must leave the forward index');
+        assert.ok(!validator.classDependents.get(PARENT_FQN)?.has(CHILD_FQN),
+            'evicted key must leave dependent sets');
+    });
+
     it('should re-register hierarchy dependents after re-walking', async () => {
         await validator.getClassFields(CHILD_FQN);
 

--- a/src/test/unit/javaFieldHierarchy.test.ts
+++ b/src/test/unit/javaFieldHierarchy.test.ts
@@ -55,7 +55,7 @@ describe('javaFieldHierarchy Unit Tests', () => {
             const fieldNames = result.fields.map(f => f.field.name);
             assert.deepStrictEqual(
                 fieldNames.sort(),
-                ['astOnlyField', 'createTime', 'createdBy', 'id', 'status', 'taskName', 'updatedBy']
+                ['astOnlyField', 'createTime', 'createdBy', 'id', 'shadowedField', 'status', 'taskName', 'updatedBy']
             );
         });
 
@@ -67,6 +67,8 @@ describe('javaFieldHierarchy Unit Tests', () => {
             assert.strictEqual(byName.get('taskName')?.className, TASK_QUERY_FQN);
             assert.strictEqual(byName.get('updatedBy')?.filePath, AUDIT_ENTITY_PATH);
             assert.strictEqual(byName.get('updatedBy')?.className, AUDIT_ENTITY_FQN);
+            assert.strictEqual(byName.get('shadowedField')?.filePath, AUDIT_ENTITY_PATH);
+            assert.strictEqual(byName.get('shadowedField')?.className, AUDIT_ENTITY_FQN);
             assert.strictEqual(byName.get('createdBy')?.filePath, BASE_ENTITY_PATH);
             assert.strictEqual(byName.get('createdBy')?.className, BASE_ENTITY_FQN);
             // Field declared with the class's own generic type parameter

--- a/src/test/unit/javaFieldHierarchy.test.ts
+++ b/src/test/unit/javaFieldHierarchy.test.ts
@@ -223,6 +223,35 @@ public class Child extends Object {
             assert.strictEqual(findClassStub.callCount, 1);
         });
 
+        it('should not attribute a secondary class\'s superclass to the visited class', async () => {
+            setupClasses({
+                Plain: `
+package com.example;
+
+public class Plain {
+    private Long id;
+}
+
+class PlainHelper extends HelperBase {
+    private String helperField;
+}
+`,
+                HelperBase: `
+package com.example;
+
+public class HelperBase {
+    private String wrongField;
+}
+`
+            });
+
+            const result = await getClassFieldsWithInheritance('com.example.Plain');
+
+            assert.deepStrictEqual(result.classChain, ['com.example.Plain']);
+            assert.ok(!result.fields.some(f => f.field.name === 'wrongField'),
+                'HelperBase fields must not leak into Plain\'s hierarchy');
+        });
+
         it('should terminate on cyclic extends chains', async () => {
             setupClasses({
                 CycleA: `

--- a/src/test/unit/javaFieldHierarchy.test.ts
+++ b/src/test/unit/javaFieldHierarchy.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for javaFieldHierarchy - inherited field resolution (issue #50)
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+    getClassFieldsWithInheritance,
+    findFieldInHierarchy
+} from '../../utils/javaFieldHierarchy';
+import * as navigationUtils from '../../utils/navigationUtils';
+import * as javaTypeResolver from '../../utils/javaTypeResolver';
+import * as fileUtils from '../../utils/fileUtils';
+
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures', 'parameter-validation');
+
+const TASK_QUERY_PATH = path.join(FIXTURES_DIR, 'TaskQuery.java');
+const AUDIT_ENTITY_PATH = path.join(FIXTURES_DIR, 'AuditEntity.java');
+const BASE_ENTITY_PATH = path.join(FIXTURES_DIR, 'BaseEntity.java');
+
+const TASK_QUERY_FQN = 'com.example.query.TaskQuery';
+const AUDIT_ENTITY_FQN = 'com.example.audit.AuditEntity';
+const BASE_ENTITY_FQN = 'com.example.entity.BaseEntity';
+
+describe('javaFieldHierarchy Unit Tests', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    /**
+     * These tests use the real fixture files on disk. Only class-file lookup is
+     * stubbed (the mocha vscode mock cannot glob the workspace); field extraction
+     * and superclass FQN resolution run the real code paths.
+     */
+    describe('with real fixture files (three-level hierarchy)', () => {
+        beforeEach(() => {
+            const classFiles: Record<string, string> = {
+                [TASK_QUERY_FQN]: TASK_QUERY_PATH,
+                [AUDIT_ENTITY_FQN]: AUDIT_ENTITY_PATH,
+                [BASE_ENTITY_FQN]: BASE_ENTITY_PATH
+            };
+            sinon.stub(navigationUtils, 'findJavaClassFile').callsFake(
+                async (className: string) => {
+                    const filePath = classFiles[className];
+                    return filePath ? vscode.Uri.file(filePath) : null;
+                }
+            );
+        });
+
+        it('should collect own and inherited fields across the whole chain', async () => {
+            const result = await getClassFieldsWithInheritance(TASK_QUERY_FQN);
+
+            const fieldNames = result.fields.map(f => f.field.name);
+            assert.deepStrictEqual(
+                fieldNames.sort(),
+                ['createTime', 'createdBy', 'id', 'status', 'taskName', 'updatedBy']
+            );
+        });
+
+        it('should record the declaring file for each field', async () => {
+            const result = await getClassFieldsWithInheritance(TASK_QUERY_FQN);
+            const byName = new Map(result.fields.map(f => [f.field.name, f]));
+
+            assert.strictEqual(byName.get('taskName')?.filePath, TASK_QUERY_PATH);
+            assert.strictEqual(byName.get('taskName')?.className, TASK_QUERY_FQN);
+            assert.strictEqual(byName.get('updatedBy')?.filePath, AUDIT_ENTITY_PATH);
+            assert.strictEqual(byName.get('updatedBy')?.className, AUDIT_ENTITY_FQN);
+            assert.strictEqual(byName.get('createdBy')?.filePath, BASE_ENTITY_PATH);
+            assert.strictEqual(byName.get('createdBy')?.className, BASE_ENTITY_FQN);
+            // Field declared with the class's own generic type parameter
+            assert.strictEqual(byName.get('id')?.filePath, BASE_ENTITY_PATH);
+        });
+
+        it('should report the visited class chain (subclass first)', async () => {
+            const result = await getClassFieldsWithInheritance(TASK_QUERY_FQN);
+            assert.deepStrictEqual(result.classChain, [
+                TASK_QUERY_FQN,
+                AUDIT_ENTITY_FQN,
+                BASE_ENTITY_FQN
+            ]);
+        });
+
+        it('findFieldInHierarchy should find an inherited field in its declaring file', async () => {
+            const result = await findFieldInHierarchy(TASK_QUERY_FQN, 'createdBy');
+
+            assert.ok(result !== null);
+            assert.strictEqual(result.field.name, 'createdBy');
+            assert.strictEqual(result.filePath, BASE_ENTITY_PATH);
+            assert.strictEqual(result.className, BASE_ENTITY_FQN);
+            assert.ok(result.field.line > 0);
+        });
+
+        it('findFieldInHierarchy should find own fields without walking further', async () => {
+            const result = await findFieldInHierarchy(TASK_QUERY_FQN, 'taskName');
+
+            assert.ok(result !== null);
+            assert.strictEqual(result.filePath, TASK_QUERY_PATH);
+        });
+
+        it('findFieldInHierarchy should return null for unknown fields', async () => {
+            const result = await findFieldInHierarchy(TASK_QUERY_FQN, 'doesNotExist');
+            assert.strictEqual(result, null);
+        });
+
+        it('should return empty result for a class that cannot be found', async () => {
+            const result = await getClassFieldsWithInheritance('com.example.Missing');
+            assert.deepStrictEqual(result.fields, []);
+            assert.deepStrictEqual(result.classChain, []);
+        });
+    });
+
+    /**
+     * Edge cases with fully stubbed file contents and type resolution.
+     */
+    describe('edge cases (stubbed contents)', () => {
+        let readFileStub: sinon.SinonStub;
+        let resolveTypeStub: sinon.SinonStub;
+        let findClassStub: sinon.SinonStub;
+
+        beforeEach(() => {
+            readFileStub = sinon.stub(fileUtils, 'readFile');
+            resolveTypeStub = sinon.stub(javaTypeResolver, 'resolveFullyQualifiedType');
+            findClassStub = sinon.stub(navigationUtils, 'findJavaClassFile');
+        });
+
+        function setupClasses(classes: Record<string, string>): void {
+            // Key: simple class name; value: file content
+            findClassStub.callsFake(async (className: string) => {
+                const simpleName = className.substring(className.lastIndexOf('.') + 1);
+                return classes[simpleName] !== undefined
+                    ? vscode.Uri.file(`/fake/${simpleName}.java`)
+                    : null;
+            });
+            readFileStub.callsFake(async (filePath: string) => {
+                const simpleName = path.basename(filePath, '.java');
+                return classes[simpleName] ?? '';
+            });
+            resolveTypeStub.callsFake(async (_javaPath: string, simpleTypeName: string) =>
+                simpleTypeName.includes('.') ? simpleTypeName : `com.example.${simpleTypeName}`
+            );
+        }
+
+        it('subclass fields should shadow same-named superclass fields', async () => {
+            setupClasses({
+                Child: `
+package com.example;
+
+public class Child extends Parent {
+    private String remark;
+}
+`,
+                Parent: `
+package com.example;
+
+public class Parent {
+    private String remark;
+    private Long id;
+}
+`
+            });
+
+            const result = await getClassFieldsWithInheritance('com.example.Child');
+            const remarkFields = result.fields.filter(f => f.field.name === 'remark');
+
+            assert.strictEqual(remarkFields.length, 1);
+            assert.strictEqual(remarkFields[0].filePath, '/fake/Child.java');
+            assert.ok(result.fields.some(f => f.field.name === 'id'));
+        });
+
+        it('should stop when the superclass has no source file in the workspace', async () => {
+            setupClasses({
+                Child: `
+package com.example;
+
+public class Child extends LibraryBase {
+    private String name;
+}
+`
+                // LibraryBase intentionally missing (third-party class)
+            });
+
+            const result = await getClassFieldsWithInheritance('com.example.Child');
+
+            assert.deepStrictEqual(result.fields.map(f => f.field.name), ['name']);
+            assert.deepStrictEqual(result.classChain, ['com.example.Child']);
+        });
+
+        it('should stop when the superclass name cannot be resolved to a FQN', async () => {
+            setupClasses({
+                Child: `
+package com.example;
+
+public class Child extends Unresolvable {
+    private String name;
+}
+`,
+                Unresolvable: 'public class Unresolvable { private Long x; }'
+            });
+            resolveTypeStub.resolves(null);
+
+            const result = await getClassFieldsWithInheritance('com.example.Child');
+
+            assert.deepStrictEqual(result.fields.map(f => f.field.name), ['name']);
+            assert.deepStrictEqual(result.classChain, ['com.example.Child']);
+        });
+
+        it('should not walk into java.lang superclasses', async () => {
+            setupClasses({
+                Child: `
+package com.example;
+
+public class Child extends Object {
+    private String name;
+}
+`
+            });
+
+            const result = await getClassFieldsWithInheritance('com.example.Child');
+
+            assert.deepStrictEqual(result.classChain, ['com.example.Child']);
+            assert.strictEqual(findClassStub.callCount, 1);
+        });
+
+        it('should terminate on cyclic extends chains', async () => {
+            setupClasses({
+                CycleA: `
+package com.example;
+
+public class CycleA extends CycleB {
+    private Long aField;
+}
+`,
+                CycleB: `
+package com.example;
+
+public class CycleB extends CycleA {
+    private Long bField;
+}
+`
+            });
+
+            const result = await getClassFieldsWithInheritance('com.example.CycleA');
+
+            assert.deepStrictEqual(
+                result.fields.map(f => f.field.name).sort(),
+                ['aField', 'bField']
+            );
+            assert.deepStrictEqual(result.classChain, ['com.example.CycleA', 'com.example.CycleB']);
+        });
+
+        it('should cap the walk at the maximum hierarchy depth', async () => {
+            const classes: Record<string, string> = {};
+            const chainLength = 15;
+            for (let i = 0; i < chainLength; i++) {
+                const extendsClause = i < chainLength - 1 ? ` extends C${i + 1}` : '';
+                classes[`C${i}`] = `
+package com.example;
+
+public class C${i}${extendsClause} {
+    private Long field${i};
+}
+`;
+            }
+            setupClasses(classes);
+
+            const result = await getClassFieldsWithInheritance('com.example.C0');
+
+            assert.strictEqual(result.classChain.length, 10);
+            assert.strictEqual(result.fields.length, 10);
+        });
+    });
+});

--- a/src/test/unit/javaFieldHierarchy.test.ts
+++ b/src/test/unit/javaFieldHierarchy.test.ts
@@ -206,7 +206,7 @@ public class Child extends Unresolvable {
             assert.deepStrictEqual(result.classChain, ['com.example.Child']);
         });
 
-        it('should not walk into java.lang superclasses', async () => {
+        it('should stop when the superclass resolves to a java.lang type', async () => {
             setupClasses({
                 Child: `
 package com.example;
@@ -216,11 +216,41 @@ public class Child extends Object {
 }
 `
             });
+            resolveTypeStub.callsFake(async (_javaPath: string, simpleTypeName: string) =>
+                simpleTypeName === 'Object' ? 'java.lang.Object' : `com.example.${simpleTypeName}`
+            );
 
             const result = await getClassFieldsWithInheritance('com.example.Child');
 
             assert.deepStrictEqual(result.classChain, ['com.example.Child']);
             assert.strictEqual(findClassStub.callCount, 1);
+        });
+
+        it('should walk user classes that shadow java.lang names', async () => {
+            // java.lang.Integer is final, so `extends Integer` can only refer
+            // to a user class shadowing the name
+            setupClasses({
+                Child: `
+package com.example;
+
+public class Child extends Integer {
+    private String name;
+}
+`,
+                Integer: `
+package com.example;
+
+public class Integer {
+    private Long shadowField;
+}
+`
+            });
+
+            const result = await getClassFieldsWithInheritance('com.example.Child');
+
+            assert.deepStrictEqual(result.classChain, ['com.example.Child', 'com.example.Integer']);
+            assert.ok(result.fields.some(f => f.field.name === 'shadowField'),
+                'fields of the shadowing user class must be inherited');
         });
 
         it('should not attribute a secondary class\'s superclass to the visited class', async () => {

--- a/src/test/unit/javaFieldHierarchy.test.ts
+++ b/src/test/unit/javaFieldHierarchy.test.ts
@@ -55,7 +55,7 @@ describe('javaFieldHierarchy Unit Tests', () => {
             const fieldNames = result.fields.map(f => f.field.name);
             assert.deepStrictEqual(
                 fieldNames.sort(),
-                ['createTime', 'createdBy', 'id', 'status', 'taskName', 'updatedBy']
+                ['astOnlyField', 'createTime', 'createdBy', 'id', 'status', 'taskName', 'updatedBy']
             );
         });
 

--- a/src/test/unit/javaFieldHierarchy.test.ts
+++ b/src/test/unit/javaFieldHierarchy.test.ts
@@ -250,6 +250,9 @@ public class HelperBase {
             assert.deepStrictEqual(result.classChain, ['com.example.Plain']);
             assert.ok(!result.fields.some(f => f.field.name === 'wrongField'),
                 'HelperBase fields must not leak into Plain\'s hierarchy');
+            assert.ok(!result.fields.some(f => f.field.name === 'helperField'),
+                'Same-file sibling class fields must not leak into Plain\'s hierarchy');
+            assert.deepStrictEqual(result.fields.map(f => f.field.name), ['id']);
         });
 
         it('should terminate on cyclic extends chains', async () => {

--- a/src/test/unit/javaFieldParser.test.ts
+++ b/src/test/unit/javaFieldParser.test.ts
@@ -454,6 +454,26 @@ public class User {
             const result = await extractJavaFields('/fake/User.java', 'User');
             assert.deepStrictEqual(result.map(f => f.name), ['name']);
         });
+
+        it('should keep collecting outer-class fields declared after a nested type', async () => {
+            const mockContent = `
+package com.example;
+
+public class User {
+    private String name;
+
+    public static class Builder {
+        private String pendingName;
+    }
+
+    private Long id;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractJavaFields('/fake/User.java', 'User');
+            assert.deepStrictEqual(result.map(f => f.name), ['name', 'id'],
+                'fields after the nested type belong to the outer class; nested fields do not');
+        });
     });
 
     // ==================== Superclass extraction ====================

--- a/src/test/unit/javaFieldParser.test.ts
+++ b/src/test/unit/javaFieldParser.test.ts
@@ -8,7 +8,8 @@ import * as vscode from 'vscode';
 import {
     extractJavaFields,
     findJavaField,
-    findJavaFieldPosition
+    findJavaFieldPosition,
+    extractSuperclassName
 } from '../../navigator/parsers/javaFieldParser';
 import * as fileUtils from '../../utils/fileUtils';
 import * as javaTreeSitterParser from '../../navigator/parsers/javaTreeSitterParser';
@@ -435,6 +436,122 @@ public class User {
             const result = await extractJavaFields('/fake/User.java');
             assert.strictEqual(result.length, 1);
             assert.strictEqual(result[0].name, 'name');
+        });
+    });
+
+    // ==================== Superclass extraction ====================
+
+    describe('extractSuperclassName (AST tier)', () => {
+        it('should extract superclass name', async () => {
+            const mockContent = `
+package com.example;
+
+public class Role extends BaseEntity {
+    private String roleName;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Role.java');
+            assert.strictEqual(result, 'BaseEntity');
+        });
+
+        it('should return null when class extends nothing', async () => {
+            const mockContent = `
+package com.example;
+
+public class Role {
+    private String roleName;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Role.java');
+            assert.strictEqual(result, null);
+        });
+    });
+
+    describe('extractSuperclassName (regex fallback, AST forced to throw)', () => {
+        beforeEach(() => {
+            sinon.stub(javaTreeSitterParser, 'extractSuperclassNameFromAST')
+                .rejects(new Error('WASM fail'));
+        });
+
+        it('should extract simple superclass name', async () => {
+            const mockContent = `
+package com.example;
+
+public class Role extends BaseEntity {
+    private String roleName;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Role.java');
+            assert.strictEqual(result, 'BaseEntity');
+        });
+
+        it('should extract superclass name without generic type arguments', async () => {
+            const mockContent = `
+package com.example;
+
+public class Role extends BaseEntity<Long> {
+    private String roleName;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Role.java');
+            assert.strictEqual(result, 'BaseEntity');
+        });
+
+        it('should extract fully-qualified superclass name', async () => {
+            const mockContent = `
+package com.example;
+
+public class Role extends com.example.entity.BaseEntity {
+    private String roleName;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Role.java');
+            assert.strictEqual(result, 'com.example.entity.BaseEntity');
+        });
+
+        it('should not capture bounded type parameter as superclass', async () => {
+            const mockContent = `
+package com.example;
+
+public class Holder<T extends Number> extends BaseHolder {
+    private T value;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Holder.java');
+            assert.strictEqual(result, 'BaseHolder');
+        });
+
+        it('should return null for class that only implements interfaces', async () => {
+            const mockContent = `
+package com.example;
+
+public class Role implements Serializable {
+    private String roleName;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Role.java');
+            assert.strictEqual(result, null);
+        });
+
+        it('should handle multi-line class declarations', async () => {
+            const mockContent = `
+package com.example;
+
+public class Role
+        extends BaseEntity {
+    private String roleName;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Role.java');
+            assert.strictEqual(result, 'BaseEntity');
         });
     });
 });

--- a/src/test/unit/javaFieldParser.test.ts
+++ b/src/test/unit/javaFieldParser.test.ts
@@ -553,5 +553,70 @@ public class Role
             const result = await extractSuperclassName('/fake/Role.java');
             assert.strictEqual(result, 'BaseEntity');
         });
+
+        it('should ignore extends clauses inside comments', async () => {
+            const mockContent = `
+package com.example;
+
+// Legacy note: class Role extends OldBase was removed
+/*
+ * class Role extends AnotherWrongBase
+ */
+public class Role extends RealBase {
+    private String roleName;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Role.java', 'Role');
+            assert.strictEqual(result, 'RealBase');
+        });
+
+        it('should return null when only a comment mentions an extends clause', async () => {
+            const mockContent = `
+package com.example;
+
+// class Role extends GhostBase
+public class Role {
+    private String roleName;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Role.java', 'Role');
+            assert.strictEqual(result, null);
+        });
+
+        it('should only match the named class when className is given', async () => {
+            const mockContent = `
+package com.example;
+
+class Helper extends HelperBase {
+    private String helperField;
+}
+
+public class Role extends RoleBase {
+    private String roleName;
+}
+`;
+            readFileStub.resolves(mockContent);
+            assert.strictEqual(await extractSuperclassName('/fake/Role.java', 'Role'), 'RoleBase');
+            assert.strictEqual(await extractSuperclassName('/fake/Role.java', 'Helper'), 'HelperBase');
+        });
+
+        it('should return null when the named class extends nothing even if another class does', async () => {
+            const mockContent = `
+package com.example;
+
+public class Role {
+    private String roleName;
+}
+
+class Helper extends HelperBase {
+    private String helperField;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Role.java', 'Role');
+            assert.strictEqual(result, null);
+        });
     });
 });

--- a/src/test/unit/javaFieldParser.test.ts
+++ b/src/test/unit/javaFieldParser.test.ts
@@ -437,6 +437,23 @@ public class User {
             assert.strictEqual(result.length, 1);
             assert.strictEqual(result[0].name, 'name');
         });
+
+        it('should only extract the named class\'s fields when className is given', async () => {
+            const mockContent = `
+package com.example;
+
+class Helper {
+    private String helperField;
+}
+
+public class User {
+    private String name;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractJavaFields('/fake/User.java', 'User');
+            assert.deepStrictEqual(result.map(f => f.name), ['name']);
+        });
     });
 
     // ==================== Superclass extraction ====================
@@ -524,6 +541,19 @@ public class Holder<T extends Number> extends BaseHolder {
 `;
             readFileStub.resolves(mockContent);
             const result = await extractSuperclassName('/fake/Holder.java');
+            assert.strictEqual(result, 'BaseHolder');
+        });
+
+        it('should handle nested generics in bounded type parameters', async () => {
+            const mockContent = `
+package com.example;
+
+public class Holder<T extends Comparable<String>> extends BaseHolder {
+    private T value;
+}
+`;
+            readFileStub.resolves(mockContent);
+            const result = await extractSuperclassName('/fake/Holder.java', 'Holder');
             assert.strictEqual(result, 'BaseHolder');
         });
 

--- a/src/test/unit/javaLSHelper.test.ts
+++ b/src/test/unit/javaLSHelper.test.ts
@@ -273,6 +273,20 @@ describe('javaLSHelper Unit Tests', () => {
             assert.strictEqual(result[2].name, 'email');
         });
 
+        it('should only return the named class symbol\'s fields when className is given', async () => {
+            stubLSReady();
+            const helperSymbol = createDocumentSymbol(
+                'Helper', '', vscode.SymbolKind.Class, 20, 13, 19, [
+                    createDocumentSymbol('helperField', 'String', vscode.SymbolKind.Field, 21, 19, 30, []),
+                ]
+            );
+            executeCommandStub.resolves([USER_CLASS_SYMBOL(), helperSymbol]);
+
+            const result = await getClassFieldsViaLS('/fake/User.java', 'User');
+            assert.ok(result !== null);
+            assert.deepStrictEqual(result.map(f => f.name), ['id', 'name', 'email']);
+        });
+
         it('should map detail to fieldType correctly', async () => {
             stubLSReady();
             executeCommandStub.resolves([USER_CLASS_SYMBOL()]);

--- a/src/test/unit/javaTreeSitterParser.test.ts
+++ b/src/test/unit/javaTreeSitterParser.test.ts
@@ -11,6 +11,7 @@ import {
     extractParametersFromAST,
     extractFieldsFromAST,
     extractNamespaceFromAST,
+    extractSuperclassNameFromAST,
     isMyBatisMapperFromAST,
 } from '../../navigator/parsers/javaTreeSitterParser';
 
@@ -846,6 +847,106 @@ public class Empty {
 `;
             const result = await extractFieldsFromAST(content);
             assert.strictEqual(result.length, 0);
+        });
+    });
+
+    describe('extractSuperclassNameFromAST', () => {
+        it('should extract simple superclass name', async () => {
+            const content = `
+package com.example.model;
+
+public class Role extends BaseEntity {
+    private String roleName;
+}
+`;
+            const result = await extractSuperclassNameFromAST(content);
+            assert.strictEqual(result, 'BaseEntity');
+        });
+
+        it('should strip generic type arguments from superclass', async () => {
+            const content = `
+package com.example.model;
+
+public class Role extends BaseEntity<Long> {
+    private String roleName;
+}
+`;
+            const result = await extractSuperclassNameFromAST(content);
+            assert.strictEqual(result, 'BaseEntity');
+        });
+
+        it('should extract fully-qualified superclass name', async () => {
+            const content = `
+package com.example.model;
+
+public class Role extends com.example.entity.BaseEntity {
+    private String roleName;
+}
+`;
+            const result = await extractSuperclassNameFromAST(content);
+            assert.strictEqual(result, 'com.example.entity.BaseEntity');
+        });
+
+        it('should extract superclass when class also implements interfaces', async () => {
+            const content = `
+package com.example.model;
+
+public class Role extends BaseEntity implements Serializable, Cloneable {
+    private String roleName;
+}
+`;
+            const result = await extractSuperclassNameFromAST(content);
+            assert.strictEqual(result, 'BaseEntity');
+        });
+
+        it('should handle bounded type parameters on the class itself', async () => {
+            const content = `
+package com.example.model;
+
+public class Holder<T extends Number> extends BaseHolder {
+    private T value;
+}
+`;
+            const result = await extractSuperclassNameFromAST(content);
+            assert.strictEqual(result, 'BaseHolder');
+        });
+
+        it('should return null when class has no extends clause', async () => {
+            const content = `
+package com.example.model;
+
+public class Role implements Serializable {
+    private String roleName;
+}
+`;
+            const result = await extractSuperclassNameFromAST(content);
+            assert.strictEqual(result, null);
+        });
+
+        it('should return null for interface-only files', async () => {
+            const content = `
+package com.example.mapper;
+
+public interface RoleMapper extends BaseMapper {
+    Role selectById(Long id);
+}
+`;
+            const result = await extractSuperclassNameFromAST(content);
+            assert.strictEqual(result, null);
+        });
+
+        it('should handle multi-line class declarations', async () => {
+            const content = `
+package com.example.model;
+
+public class Role
+        extends BaseEntity<Long>
+        implements Serializable {
+    private String roleName;
+}
+`;
+            const result = await extractSuperclassNameFromAST(content);
+            assert.strictEqual(result, 'BaseEntity');
         });
     });
 });

--- a/src/test/unit/javaTreeSitterParser.test.ts
+++ b/src/test/unit/javaTreeSitterParser.test.ts
@@ -884,6 +884,24 @@ public class Role {
             assert.deepStrictEqual(result.map(f => f.name), ['roleName']);
         });
 
+        it('should ignore a nested class with the same simple name as the target class', async () => {
+            const content = `
+package com.example.model;
+
+class Other {
+    static class Role {
+        private String wrongField;
+    }
+}
+
+public class Role {
+    private String roleName;
+}
+`;
+            const result = await extractFieldsFromAST(content, 'Role');
+            assert.deepStrictEqual(result.map(f => f.name), ['roleName']);
+        });
+
         it('should return empty array when the named class does not exist', async () => {
             const content = `
 package com.example.model;
@@ -1010,6 +1028,22 @@ public class Role extends RoleBase {
 `;
             assert.strictEqual(await extractSuperclassNameFromAST(content, 'Role'), 'RoleBase');
             assert.strictEqual(await extractSuperclassNameFromAST(content, 'Helper'), 'HelperBase');
+        });
+
+        it('should ignore a nested class with the same simple name as the target class', async () => {
+            const content = `
+package com.example.model;
+
+class Other {
+    static class Role extends WrongBase {
+    }
+}
+
+public class Role extends RoleBase {
+}
+`;
+            const result = await extractSuperclassNameFromAST(content, 'Role');
+            assert.strictEqual(result, 'RoleBase');
         });
 
         it('should return null when the named class extends nothing even if another class does', async () => {

--- a/src/test/unit/javaTreeSitterParser.test.ts
+++ b/src/test/unit/javaTreeSitterParser.test.ts
@@ -848,6 +848,53 @@ public class Empty {
             const result = await extractFieldsFromAST(content);
             assert.strictEqual(result.length, 0);
         });
+
+        it('should only return the named class\'s fields when className is given', async () => {
+            const content = `
+package com.example.model;
+
+class Helper {
+    private String helperField;
+}
+
+public class Role {
+    private String roleName;
+}
+`;
+            const roleFields = await extractFieldsFromAST(content, 'Role');
+            assert.deepStrictEqual(roleFields.map(f => f.name), ['roleName']);
+
+            const helperFields = await extractFieldsFromAST(content, 'Helper');
+            assert.deepStrictEqual(helperFields.map(f => f.name), ['helperField']);
+        });
+
+        it('should exclude nested class fields when className targets the outer class', async () => {
+            const content = `
+package com.example.model;
+
+public class Role {
+    private String roleName;
+
+    public static class Builder {
+        private String pendingName;
+    }
+}
+`;
+            const result = await extractFieldsFromAST(content, 'Role');
+            assert.deepStrictEqual(result.map(f => f.name), ['roleName']);
+        });
+
+        it('should return empty array when the named class does not exist', async () => {
+            const content = `
+package com.example.model;
+
+public class Role {
+    private String roleName;
+}
+`;
+            const result = await extractFieldsFromAST(content, 'Missing');
+            assert.strictEqual(result.length, 0);
+        });
     });
 
     describe('extractSuperclassNameFromAST', () => {

--- a/src/test/unit/javaTreeSitterParser.test.ts
+++ b/src/test/unit/javaTreeSitterParser.test.ts
@@ -948,5 +948,49 @@ public class Role
             const result = await extractSuperclassNameFromAST(content);
             assert.strictEqual(result, 'BaseEntity');
         });
+
+        it('should only inspect the named class when className is given', async () => {
+            const content = `
+package com.example.model;
+
+class Helper extends HelperBase {
+    private String helperField;
+}
+
+public class Role extends RoleBase {
+    private String roleName;
+}
+`;
+            assert.strictEqual(await extractSuperclassNameFromAST(content, 'Role'), 'RoleBase');
+            assert.strictEqual(await extractSuperclassNameFromAST(content, 'Helper'), 'HelperBase');
+        });
+
+        it('should return null when the named class extends nothing even if another class does', async () => {
+            const content = `
+package com.example.model;
+
+public class Role {
+    private String roleName;
+
+    public static class Builder extends AbstractBuilder {
+        private String pending;
+    }
+}
+`;
+            const result = await extractSuperclassNameFromAST(content, 'Role');
+            assert.strictEqual(result, null);
+        });
+
+        it('should return null when the named class does not exist in the file', async () => {
+            const content = `
+package com.example.model;
+
+public class Role extends BaseEntity {
+    private String roleName;
+}
+`;
+            const result = await extractSuperclassNameFromAST(content, 'Missing');
+            assert.strictEqual(result, null);
+        });
     });
 });

--- a/src/test/unit/javaTypeResolver.test.ts
+++ b/src/test/unit/javaTypeResolver.test.ts
@@ -197,10 +197,69 @@ public interface UserMapper {
         assert.strictEqual(result, null);
     });
 
-    it('should not match wildcard imports', async () => {
+    it('should not resolve wildcard import when the package has no matching file', async () => {
         fsReadFileStub.resolves(JAVA_CONTENT_WILDCARD_IMPORT);
         initTreeSitterStub.resolves(true);
         resolveTypeViaLSStub.resolves(null);
+
+        const result = await resolveFullyQualifiedType('/fake/UserMapper.java', 'User');
+        assert.strictEqual(result, null);
+    });
+
+    it('should resolve via wildcard import when the package contains the type', async () => {
+        fsReadFileStub.resolves(JAVA_CONTENT_WILDCARD_IMPORT);
+        initTreeSitterStub.resolves(true);
+        resolveTypeViaLSStub.resolves(null);
+        findFilesStub.callsFake(async (include: string) =>
+            include === '**/com/example/User.java'
+                ? [vscode.Uri.file('/fake/com/example/User.java')]
+                : []
+        );
+
+        const result = await resolveFullyQualifiedType('/fake/UserMapper.java', 'User');
+        assert.strictEqual(result, 'com.example.User');
+    });
+
+    it('should prefer same-package resolution over wildcard imports', async () => {
+        const content = `package com.example.mapper;
+
+import com.example.common.*;
+
+public interface UserMapper {
+    User selectById(Long id);
+}
+`;
+        fsReadFileStub.resolves(content);
+        initTreeSitterStub.resolves(true);
+        resolveTypeViaLSStub.resolves(null);
+        // Both the same-package file and the wildcard-package file exist
+        findFilesStub.callsFake(async (include: string) =>
+            include === '**/com/example/mapper/User.java' || include === '**/com/example/common/User.java'
+                ? [vscode.Uri.file('/fake/' + include.substring(3))]
+                : []
+        );
+
+        const result = await resolveFullyQualifiedType('/fake/UserMapper.java', 'User');
+        assert.strictEqual(result, 'com.example.mapper.User');
+    });
+
+    it('should ignore static wildcard imports', async () => {
+        const content = `package com.example.mapper;
+
+import static com.example.util.Constants.*;
+
+public interface UserMapper {
+    User selectById(Long id);
+}
+`;
+        fsReadFileStub.resolves(content);
+        initTreeSitterStub.resolves(true);
+        resolveTypeViaLSStub.resolves(null);
+        findFilesStub.callsFake(async (include: string) =>
+            include === '**/com/example/util/Constants/User.java' || include === '**/com/example/util/Constants.User.java'
+                ? [vscode.Uri.file('/fake/should-not-happen.java')]
+                : []
+        );
 
         const result = await resolveFullyQualifiedType('/fake/UserMapper.java', 'User');
         assert.strictEqual(result, null);

--- a/src/test/unit/javaTypeResolver.test.ts
+++ b/src/test/unit/javaTypeResolver.test.ts
@@ -151,6 +151,24 @@ public interface UserMapper {
         assert.strictEqual(result, 'com.example.entity.User');
     });
 
+    it('should prefer same-package resolution over Java LS', async () => {
+        fsReadFileStub.resolves(JAVA_CONTENT_NO_IMPORT);
+        initTreeSitterStub.resolves(true);
+        // LS knows a same-named class from another package
+        resolveTypeViaLSStub.resolves('com.other.entity.User');
+        findFilesStub.callsFake(async (include: string) =>
+            include === '**/com/example/mapper/User.java'
+                ? [vscode.Uri.file('/fake/com/example/mapper/User.java')]
+                : []
+        );
+
+        const result = await resolveFullyQualifiedType('/fake/UserMapper.java', 'User');
+        assert.strictEqual(result, 'com.example.mapper.User',
+            'same-package type must win over an LS match from another package');
+        assert.strictEqual(resolveTypeViaLSStub.called, false,
+            'LS should not even be consulted when same-package resolution succeeds');
+    });
+
     it('should resolve via same-package when all tiers fail', async () => {
         fsReadFileStub.resolves(JAVA_CONTENT_NO_IMPORT);
         initTreeSitterStub.resolves(false);

--- a/src/utils/LRUCache.ts
+++ b/src/utils/LRUCache.ts
@@ -5,9 +5,17 @@
 export class LRUCache<K, V> {
     private cache: Map<K, V> = new Map();
     private maxSize: number;
+    private onEvict?: (key: K, value: V) => void;
 
-    constructor(maxSize: number) {
+    /**
+     * @param maxSize - Maximum number of entries to keep
+     * @param onEvict - Called when an entry is silently evicted because the
+     *                  cache is full. Not called for explicit delete()/clear(),
+     *                  which the owner already knows about.
+     */
+    constructor(maxSize: number, onEvict?: (key: K, value: V) => void) {
         this.maxSize = maxSize;
+        this.onEvict = onEvict;
     }
 
     get(key: K): V | undefined {
@@ -28,7 +36,11 @@ export class LRUCache<K, V> {
             // Remove least recently used (first item)
             const firstKey = this.cache.keys().next().value as K;
             if (firstKey !== undefined) {
+                const evictedValue = this.cache.get(firstKey);
                 this.cache.delete(firstKey);
+                if (this.onEvict && evictedValue !== undefined) {
+                    this.onEvict(firstKey, evictedValue);
+                }
             }
         }
         this.cache.set(key, value);

--- a/src/utils/javaFieldHierarchy.ts
+++ b/src/utils/javaFieldHierarchy.ts
@@ -60,8 +60,12 @@ async function* walkClassHierarchy(
 
         yield { className: current, filePath: file.fsPath };
 
-        current = await resolveSuperclass(file.fsPath);
+        current = await resolveSuperclass(file.fsPath, simpleNameOf(current));
     }
+}
+
+function simpleNameOf(className: string): string {
+    return className.substring(className.lastIndexOf('.') + 1);
 }
 
 /**
@@ -117,11 +121,13 @@ export async function findFieldInHierarchy(
 }
 
 /**
- * Resolve the fully-qualified superclass name of the class declared in a file
+ * Resolve the fully-qualified superclass name of a specific class declared in a file.
+ * The class name anchors extraction so other types in the same compilation unit
+ * cannot be mistaken for the class's superclass.
  */
-async function resolveSuperclass(filePath: string): Promise<string | null> {
+async function resolveSuperclass(filePath: string, className: string): Promise<string | null> {
     try {
-        const superclassName = await extractSuperclassName(filePath);
+        const superclassName = await extractSuperclassName(filePath, className);
         if (!superclassName || isBuiltInType(superclassName)) {
             return null;
         }

--- a/src/utils/javaFieldHierarchy.ts
+++ b/src/utils/javaFieldHierarchy.ts
@@ -1,0 +1,137 @@
+/**
+ * Resolves Java class fields including fields inherited from superclasses,
+ * by walking the `extends` chain across workspace source files.
+ *
+ * Shared by parameter validation and XML → Java field navigation so that
+ * inherited fields behave the same everywhere (issue #50).
+ */
+
+import { JavaField } from '../types';
+import { extractJavaFields, extractSuperclassName } from '../navigator/parsers/javaFieldParser';
+import { resolveFullyQualifiedType } from './javaTypeResolver';
+import { findJavaClassFile } from './navigationUtils';
+import { isBuiltInType } from './javaTypeUtils';
+
+/**
+ * A field together with the class and file that declare it
+ */
+export interface ResolvedJavaField {
+    field: JavaField;
+    /** Absolute path of the Java file declaring the field */
+    filePath: string;
+    /** Fully-qualified name of the declaring class */
+    className: string;
+}
+
+/**
+ * Fields of a class hierarchy plus the chain of classes that contributed them
+ */
+export interface ClassHierarchyFields {
+    /** Own and inherited fields; subclass fields shadow same-named superclass fields */
+    fields: ResolvedJavaField[];
+    /** Fully-qualified names of all resolved classes in the chain (subclass first) */
+    classChain: string[];
+}
+
+// Guard against pathological or cyclic extends chains
+const MAX_HIERARCHY_DEPTH = 10;
+
+/**
+ * Walk a class's `extends` chain, yielding each class that can be resolved
+ * to a workspace source file (subclass first). Stops at classes outside the
+ * workspace (JDK/library types), cycles, or MAX_HIERARCHY_DEPTH.
+ */
+async function* walkClassHierarchy(
+    className: string
+): AsyncGenerator<{ className: string; filePath: string }> {
+    const visited = new Set<string>();
+    let current: string | null = className;
+
+    while (current && visited.size < MAX_HIERARCHY_DEPTH) {
+        if (visited.has(current)) {
+            break;
+        }
+        visited.add(current);
+
+        const file = await findJavaClassFile(current);
+        if (!file) {
+            break;
+        }
+
+        yield { className: current, filePath: file.fsPath };
+
+        current = await resolveSuperclass(file.fsPath);
+    }
+}
+
+/**
+ * Get all fields of a class including inherited ones.
+ * Fields declared in a subclass shadow same-named superclass fields.
+ *
+ * @param className - Fully-qualified class name (e.g., "com.example.Role")
+ * @returns Resolved fields and the class chain that contributed them
+ */
+export async function getClassFieldsWithInheritance(
+    className: string
+): Promise<ClassHierarchyFields> {
+    const fields: ResolvedJavaField[] = [];
+    const seenFieldNames = new Set<string>();
+    const classChain: string[] = [];
+
+    for await (const cls of walkClassHierarchy(className)) {
+        classChain.push(cls.className);
+
+        const ownFields = await extractJavaFields(cls.filePath);
+        for (const field of ownFields) {
+            if (!seenFieldNames.has(field.name)) {
+                seenFieldNames.add(field.name);
+                fields.push({ field, filePath: cls.filePath, className: cls.className });
+            }
+        }
+    }
+
+    return { fields, classChain };
+}
+
+/**
+ * Find a field by name in a class or any of its superclasses.
+ * Returns as soon as the field is found, without walking the rest of the chain.
+ *
+ * @param className - Fully-qualified class name (e.g., "com.example.Role")
+ * @param fieldName - Field name to find
+ * @returns The field with its declaring class/file, or null
+ */
+export async function findFieldInHierarchy(
+    className: string,
+    fieldName: string
+): Promise<ResolvedJavaField | null> {
+    for await (const cls of walkClassHierarchy(className)) {
+        const ownFields = await extractJavaFields(cls.filePath);
+        const field = ownFields.find(f => f.name === fieldName);
+        if (field) {
+            return { field, filePath: cls.filePath, className: cls.className };
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Resolve the fully-qualified superclass name of the class declared in a file
+ */
+async function resolveSuperclass(filePath: string): Promise<string | null> {
+    try {
+        const superclassName = await extractSuperclassName(filePath);
+        if (!superclassName || isBuiltInType(superclassName)) {
+            return null;
+        }
+        const fullyQualified = await resolveFullyQualifiedType(filePath, superclassName);
+        if (!fullyQualified || isBuiltInType(fullyQualified)) {
+            return null;
+        }
+        return fullyQualified;
+    } catch (error) {
+        console.warn(`[javaFieldHierarchy] Failed to resolve superclass of ${filePath}:`, error);
+        return null;
+    }
+}

--- a/src/utils/javaFieldHierarchy.ts
+++ b/src/utils/javaFieldHierarchy.ts
@@ -128,9 +128,13 @@ export async function findFieldInHierarchy(
 async function resolveSuperclass(filePath: string, className: string): Promise<string | null> {
     try {
         const superclassName = await extractSuperclassName(filePath, className);
-        if (!superclassName || isBuiltInType(superclassName)) {
+        if (!superclassName) {
             return null;
         }
+        // Only the RESOLVED name is checked against built-ins: java.lang's
+        // extendable-looking short names (String, Integer, ...) are final, so a
+        // compiling `extends Integer` can only mean a user class shadowing the
+        // name — resolution must be allowed to find it
         const fullyQualified = await resolveFullyQualifiedType(filePath, superclassName);
         if (!fullyQualified || isBuiltInType(fullyQualified)) {
             return null;

--- a/src/utils/javaFieldHierarchy.ts
+++ b/src/utils/javaFieldHierarchy.ts
@@ -85,7 +85,7 @@ export async function getClassFieldsWithInheritance(
     for await (const cls of walkClassHierarchy(className)) {
         classChain.push(cls.className);
 
-        const ownFields = await extractJavaFields(cls.filePath);
+        const ownFields = await extractJavaFields(cls.filePath, simpleNameOf(cls.className));
         for (const field of ownFields) {
             if (!seenFieldNames.has(field.name)) {
                 seenFieldNames.add(field.name);
@@ -110,7 +110,7 @@ export async function findFieldInHierarchy(
     fieldName: string
 ): Promise<ResolvedJavaField | null> {
     for await (const cls of walkClassHierarchy(className)) {
-        const ownFields = await extractJavaFields(cls.filePath);
+        const ownFields = await extractJavaFields(cls.filePath, simpleNameOf(cls.className));
         const field = ownFields.find(f => f.name === fieldName);
         if (field) {
             return { field, filePath: cls.filePath, className: cls.className };

--- a/src/utils/javaLSHelper.ts
+++ b/src/utils/javaLSHelper.ts
@@ -74,9 +74,15 @@ export async function resolveTypeViaLS(simpleTypeName: string): Promise<string |
 /**
  * Get class fields using Java Language Server document symbol provider
  *
+ * @param classFilePath - Path to the Java file
+ * @param className - When given, only the matching class symbol's fields are
+ *                    returned, so other types in the same file are excluded
  * @returns Array of JavaField or null if LS unavailable
  */
-export async function getClassFieldsViaLS(classFilePath: string): Promise<JavaField[] | null> {
+export async function getClassFieldsViaLS(
+    classFilePath: string,
+    className?: string
+): Promise<JavaField[] | null> {
     try {
         if (!await isJavaLSReady()) {
             return null;
@@ -96,6 +102,9 @@ export async function getClassFieldsViaLS(classFilePath: string): Promise<JavaFi
 
         // DocumentSymbol is hierarchical - fields are children of class symbols
         for (const symbol of symbols) {
+            if (className && symbol.name !== className) {
+                continue;
+            }
             if (
                 symbol.kind === vscode.SymbolKind.Class ||
                 symbol.kind === vscode.SymbolKind.Interface

--- a/src/utils/javaTypeResolver.ts
+++ b/src/utils/javaTypeResolver.ts
@@ -1,6 +1,7 @@
 /**
- * Three-tier fallback type resolver: WASM (tree-sitter) → Java LS → Regex
- * Resolves simple Java type names to fully-qualified class names
+ * Resolves simple Java type names to fully-qualified class names, following
+ * Java's import precedence: explicit imports → same package → wildcard
+ * imports → Java LS (classpath types without workspace sources)
  */
 
 import * as vscode from 'vscode';
@@ -11,12 +12,14 @@ import { WORKSPACE_EXCLUDE_PATTERN } from './fileUtils';
 /**
  * Resolve a simple type name to its fully-qualified name from a Java source file.
  *
- * Three-tier fallback:
- * 1. WASM (tree-sitter): Verify parser available, extract imports via regex
- *    (import syntax is fixed, regex is reliable here; tree-sitter confirms Java parsing works)
- * 2. Java LS: Use workspace symbol provider via Red Hat Java extension
- *    (finds classes on classpath, not just source files)
- * 3. Regex: Scan import lines + same-package fallback
+ * Resolution follows Java's own precedence for simple names, with the Java LS
+ * as a last resort for classpath types that have no workspace source:
+ * 1. Explicit imports (AST-verified when tree-sitter is available; import
+ *    syntax is fixed, so regex extraction is reliable either way)
+ * 2. Same package (workspace file check)
+ * 3. Wildcard imports (workspace file check)
+ * 4. Java LS workspace symbols — a symbol search returns the first matching
+ *    simple name from anywhere, so it must not outrank the same-package rule
  *
  * @param javaPath - Path to the Java file containing the type reference
  * @param simpleTypeName - Simple class name (e.g., "User")
@@ -34,7 +37,7 @@ export async function resolveFullyQualifiedType(
     const fs = await import('fs');
     const content = await fs.promises.readFile(javaPath, 'utf-8');
 
-    // Tier 1: WASM-backed import resolution
+    // Tier 1: explicit imports (WASM-backed when available)
     // Use tree-sitter availability as a signal that Java parsing is working,
     // then extract imports (which have fixed syntax, so regex is reliable)
     try {
@@ -46,10 +49,32 @@ export async function resolveFullyQualifiedType(
             }
         }
     } catch {
-        // fallthrough to next tier
+        // fallthrough
     }
 
-    // Tier 2: Java Language Server (finds classpath classes, not just source files)
+    const fromImports = resolveFromImports(content, simpleTypeName);
+    if (fromImports) {
+        console.log(`[javaTypeResolver] Regex resolved ${simpleTypeName} to ${fromImports}`);
+        return fromImports;
+    }
+
+    // Tier 2: same package — in Java, same-package types take precedence over
+    // wildcard imports and anything found on the wider classpath
+    const fromSamePackage = await resolveFromSamePackage(content, simpleTypeName);
+    if (fromSamePackage) {
+        console.log(`[javaTypeResolver] Same-package resolved ${simpleTypeName} to ${fromSamePackage}`);
+        return fromSamePackage;
+    }
+
+    // Tier 3: wildcard imports
+    const fromWildcard = await resolveFromWildcardImports(content, simpleTypeName);
+    if (fromWildcard) {
+        console.log(`[javaTypeResolver] Wildcard-import resolved ${simpleTypeName} to ${fromWildcard}`);
+        return fromWildcard;
+    }
+
+    // Tier 4: Java Language Server (finds classpath classes without workspace
+    // sources; ranked last because it matches simple names from any package)
     try {
         const result = await resolveTypeViaLS(simpleTypeName);
         if (result) {
@@ -57,31 +82,11 @@ export async function resolveFullyQualifiedType(
             return result;
         }
     } catch {
-        // fallthrough to next tier
+        // fallthrough
     }
 
-    // Tier 3: Regex fallback (imports + same-package check)
-    const fromImports = resolveFromImports(content, simpleTypeName);
-    if (fromImports) {
-        console.log(`[javaTypeResolver] Regex resolved ${simpleTypeName} to ${fromImports}`);
-        return fromImports;
-    }
-
-    // Same-package fallback
-    const fromSamePackage = await resolveFromSamePackage(content, simpleTypeName);
-    if (fromSamePackage) {
-        console.log(`[javaTypeResolver] Same-package resolved ${simpleTypeName} to ${fromSamePackage}`);
-        return fromSamePackage;
-    }
-
-    // Wildcard-import fallback (lowest precedence, matching Java import semantics)
-    const fromWildcard = await resolveFromWildcardImports(content, simpleTypeName);
-    if (fromWildcard) {
-        console.log(`[javaTypeResolver] Wildcard-import resolved ${simpleTypeName} to ${fromWildcard}`);
-    } else {
-        console.log(`[javaTypeResolver] Could not resolve ${simpleTypeName}`);
-    }
-    return fromWildcard;
+    console.log(`[javaTypeResolver] Could not resolve ${simpleTypeName}`);
+    return null;
 }
 
 /**

--- a/src/utils/javaTypeResolver.ts
+++ b/src/utils/javaTypeResolver.ts
@@ -68,13 +68,20 @@ export async function resolveFullyQualifiedType(
     }
 
     // Same-package fallback
-    const result = await resolveFromSamePackage(content, simpleTypeName);
-    if (result) {
-        console.log(`[javaTypeResolver] Same-package resolved ${simpleTypeName} to ${result}`);
+    const fromSamePackage = await resolveFromSamePackage(content, simpleTypeName);
+    if (fromSamePackage) {
+        console.log(`[javaTypeResolver] Same-package resolved ${simpleTypeName} to ${fromSamePackage}`);
+        return fromSamePackage;
+    }
+
+    // Wildcard-import fallback (lowest precedence, matching Java import semantics)
+    const fromWildcard = await resolveFromWildcardImports(content, simpleTypeName);
+    if (fromWildcard) {
+        console.log(`[javaTypeResolver] Wildcard-import resolved ${simpleTypeName} to ${fromWildcard}`);
     } else {
         console.log(`[javaTypeResolver] Could not resolve ${simpleTypeName}`);
     }
-    return result;
+    return fromWildcard;
 }
 
 /**
@@ -94,6 +101,44 @@ function resolveFromImports(content: string, simpleTypeName: string): string | n
         const importMatch = trimmed.match(/import\s+([\w.]+\.(\w+))\s*;/);
         if (importMatch && importMatch[2] === simpleTypeName) {
             return importMatch[1];
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Resolve type from wildcard import declarations (e.g., `import com.example.common.*;`)
+ * by checking whether the imported package contains a matching source file in the
+ * workspace. Static imports are ignored — they import members, not types.
+ */
+async function resolveFromWildcardImports(content: string, simpleTypeName: string): Promise<string | null> {
+    const lines = content.split('\n');
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+
+        // Stop at the class/interface declaration
+        if (trimmed.match(/(?:class|interface|enum)\s+/)) {
+            break;
+        }
+
+        const wildcardMatch = trimmed.match(/^import\s+([\w.]+)\.\*\s*;/);
+        if (!wildcardMatch) {
+            continue;
+        }
+
+        const candidate = `${wildcardMatch[1]}.${simpleTypeName}`;
+        const pathPattern = candidate.replace(/\./g, '/') + '.java';
+
+        const files = await vscode.workspace.findFiles(
+            `**/${pathPattern}`,
+            WORKSPACE_EXCLUDE_PATTERN,
+            1
+        );
+
+        if (files.length > 0) {
+            return candidate;
         }
     }
 


### PR DESCRIPTION
## Summary

Resolves issue #50 by implementing comprehensive support for inherited Java fields across the extension's parameter validation and XML-to-Java navigation features. Previously, only fields declared directly on a class were recognized; now the extension walks the `extends` chain to resolve fields inherited from superclasses.

## Key Changes

- **New Module: `javaFieldHierarchy.ts`** - Core utility for walking Java class hierarchies
  - `getClassFieldsWithInheritance()`: Collects own and inherited fields across the entire superclass chain
  - `findFieldInHierarchy()`: Locates a specific field by name, stopping at the declaring class
  - Handles edge cases: cyclic inheritance, missing workspace files, built-in types (java.lang.*), and depth limits (max 10 levels)
  - Subclass fields properly shadow same-named superclass fields

- **Parser Enhancement: `javaFieldParser.ts` & `javaTreeSitterParser.ts`**
  - New `extractSuperclassName()` function with two-tier fallback (WASM → Regex)
  - New `extractSuperclassNameFromAST()` for tree-sitter-based extraction
  - Strips generic type arguments (e.g., `BaseEntity<Long>` → `BaseEntity`)
  - Handles fully-qualified superclass names and multi-line class declarations

- **ParameterValidator Updates**
  - Now uses `getClassFieldsWithInheritance()` instead of direct field extraction
  - Implements smart cache invalidation: editing a superclass invalidates cached entries of all its subclasses
  - Tracks class dependencies via `classDependents` map to efficiently invalidate affected entries
  - Maintains backward compatibility with existing parameter validation logic

- **Navigation Provider Updates**
  - `XmlParameterDefinitionProvider`: Uses `findFieldInHierarchy()` to navigate to inherited fields
  - `XmlResultMapPropertyDefinitionProvider`: Uses `findFieldInHierarchy()` for property navigation
  - Both providers now correctly land on the file that actually declares the field, even if inherited

- **Comprehensive Test Coverage**
  - Unit tests for `javaFieldHierarchy` with real fixture files (3-level hierarchy: TaskQuery → AuditEntity → BaseEntity<Long>)
  - Edge case tests: field shadowing, missing superclasses, unresolvable types, cyclic chains, depth limits
  - Unit tests for superclass extraction (AST and regex fallback)
  - Integration tests for parameter validation with inherited fields
  - Integration tests for XML-to-Java navigation with inherited fields
  - Cache invalidation tests for ParameterValidator

- **Test Fixtures**
  - Added 3-level class hierarchy: `TaskQuery` → `AuditEntity` → `BaseEntity<Long>`
  - Added `TaskMapper.xml` and `TaskMapper.java` demonstrating inherited field usage
  - Fixtures validate both parameter validation and navigation scenarios

## Implementation Details

- **Hierarchy Walking**: Uses async generator pattern for memory efficiency and early termination
- **Cycle Detection**: Maintains visited set to prevent infinite loops in pathological inheritance chains
- **Depth Limiting**: Caps hierarchy walk at 10 levels to prevent performance degradation
- **Type Resolution**: Leverages existing `resolveFullyQualifiedType()` to convert simple names to FQNs
- **Cache Strategy**: Field cache now tracks class dependencies, enabling targeted invalidation when superclasses change
- **Backward Compatibility**: All changes are additive; existing APIs remain unchanged

https://claude.ai/code/session_018zwgiFf2M4SCLsqiWnRrYD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core XML parameter validation, definition navigation, and type resolution precedence; incorrect hierarchy or cache invalidation could cause false diagnostics or wrong jump targets, though coverage is extensive.
> 
> **Overview**
> Fixes **issue #50** by treating **inherited** Java fields like declared ones for MyBatis XML parameter checks and go-to-definition.
> 
> A new **`javaFieldHierarchy`** helper walks the `extends` chain (with depth/cycle guards and **subclass shadowing**), backed by **`extractSuperclassName`** and **class-scoped** field parsing so multi-type source files do not leak the wrong members. **`ParameterValidator`** now builds valid parameter names from that hierarchy and keeps an **inheritance-aware field cache** (superclass edits and LRU eviction invalidate dependents; saving Java re-runs open XML diagnostics). **`XmlParameterDefinitionProvider`** and **`XmlResultMapPropertyDefinitionProvider`** jump to the **declaring** superclass file instead of only the parameter/result type class.
> 
> **`javaTypeResolver`** is reordered to match Java precedence (explicit import → same package → wildcard → Java LS). **`esbuild`** forces the **CommonJS** `web-tree-sitter` entry so bundled parsing keeps working. Fixtures, Java integration samples, and unit/integration tests cover multi-level hierarchies, shadowing, and cache behavior; some navigation integration suites are re-enabled or fixed for workspace-scoped runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 670d14922e43ec758cde8d5f6af8d5626c2020b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->