### PR TITLE
Generate MyBatis-Plus service impl and REST controller; add templates, metadata, types, webview and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Generate complete MyBatis boilerplate code from DDL SQL statements with an inter
 - **Mapper interfaces** with CRUD methods
 - **XML mapping files** with complete SQL statements (insert, update, delete, select)
 - **Service classes** with common business logic
+- **MyBatis-Plus service interfaces, service implementations, and REST controllers** when MyBatis-Plus is enabled
 
 **Supported databases:**
 - MySQL (AUTO_INCREMENT, ENGINE, COMMENT syntax)

--- a/src/generator/template/controller.ejs
+++ b/src/generator/template/controller.ejs
@@ -1,0 +1,54 @@
+package <%= packageName %>;
+
+<%_ imports.forEach(function(imp) { -%>
+import <%= imp %>;
+<%_ }); -%>
+
+/**
+<%_ if (comment) { -%>
+ * <%= comment %>
+<%_ } -%>
+ *
+ * @author <%= author %>
+ * @since <%= since %>
+ */
+@RestController
+@RequestMapping("<%= requestPath %>")
+<%_ if (useLombok) { -%>
+@RequiredArgsConstructor
+<%_ } -%>
+public class <%= domainName %><%= classSuffix %> {
+<%_ if (useLombok) { -%>
+
+    private final <%= serviceClassName %> <%= serviceClassName.charAt(0).toLowerCase() + serviceClassName.slice(1) %>;
+<%_ } else { -%>
+
+    @Autowired
+    private <%= serviceClassName %> <%= serviceClassName.charAt(0).toLowerCase() + serviceClassName.slice(1) %>;
+<%_ } -%>
+
+    @GetMapping("/{id}")
+    public <%= entityClassName %> getById(@PathVariable <%= primaryKeyType %> id) {
+        return <%= serviceClassName.charAt(0).toLowerCase() + serviceClassName.slice(1) %>.getById(id);
+    }
+
+    @GetMapping
+    public List<<%= entityClassName %>> list() {
+        return <%= serviceClassName.charAt(0).toLowerCase() + serviceClassName.slice(1) %>.list();
+    }
+
+    @PostMapping
+    public boolean save(@RequestBody <%= entityClassName %> entity) {
+        return <%= serviceClassName.charAt(0).toLowerCase() + serviceClassName.slice(1) %>.save(entity);
+    }
+
+    @PutMapping
+    public boolean update(@RequestBody <%= entityClassName %> entity) {
+        return <%= serviceClassName.charAt(0).toLowerCase() + serviceClassName.slice(1) %>.updateById(entity);
+    }
+
+    @DeleteMapping("/{id}")
+    public boolean remove(@PathVariable <%= primaryKeyType %> id) {
+        return <%= serviceClassName.charAt(0).toLowerCase() + serviceClassName.slice(1) %>.removeById(id);
+    }
+}

--- a/src/generator/template/service-impl.ejs
+++ b/src/generator/template/service-impl.ejs
@@ -1,0 +1,17 @@
+package <%= packageName %>;
+
+<%_ imports.forEach(function(imp) { -%>
+import <%= imp %>;
+<%_ }); -%>
+
+/**
+<%_ if (comment) { -%>
+ * <%= comment %>
+<%_ } -%>
+ *
+ * @author <%= author %>
+ * @since <%= since %>
+ */
+@Service
+public class <%= domainName %><%= classSuffix %> extends ServiceImpl<<%= mapperClassName %>, <%= entityClassName %>> implements <%= serviceClassName %> {
+}

--- a/src/generator/template/service.ejs
+++ b/src/generator/template/service.ejs
@@ -10,6 +10,10 @@ import <%= imp %>;
  * @author <%= author %>
  * @since <%= date %>
  */
+<%_ if (useMyBatisPlus) { -%>
+public interface <%= className %> extends IService<<%= entityClassName %>> {
+}
+<%_ } else { -%>
 @Service
 <%_ if (useLombok) { -%>
 @RequiredArgsConstructor
@@ -74,3 +78,4 @@ public class <%= className %> {
     }
 
 }
+<%_ } -%>

--- a/src/generator/template/templateGenerator.ts
+++ b/src/generator/template/templateGenerator.ts
@@ -9,6 +9,8 @@ import {
     MapperGenerateMetadata,
     XmlGenerateMetadata,
     ServiceGenerateMetadata,
+    ServiceImplGenerateMetadata,
+    ControllerGenerateMetadata,
     GenerateReuslt,
 } from '../type';
 import {
@@ -134,13 +136,45 @@ export class CodeGenerator {
         };
     }
 
+    generateServiceImpl(templatePath: string = path.join(__dirname, 'service-impl.ejs')): GenerateReuslt {
+        const metadata = this.buildServiceImplMetadata();
+        const content = this.renderTemplate(templatePath, metadata);
+        const className = metadata.domainName + metadata.classSuffix;
+
+        return {
+            name: `${className}.java`,
+            outputPath: this.buildOutputPath(metadata.packageName, className, 'java'),
+            content,
+            type: 'java',
+            metadata,
+        };
+    }
+
+    generateController(templatePath: string = path.join(__dirname, 'controller.ejs')): GenerateReuslt {
+        const metadata = this.buildControllerMetadata();
+        const content = this.renderTemplate(templatePath, metadata);
+        const className = metadata.domainName + metadata.classSuffix;
+
+        return {
+            name: `${className}.java`,
+            outputPath: this.buildOutputPath(metadata.packageName, className, 'java'),
+            content,
+            type: 'java',
+            metadata,
+        };
+    }
+
     generateAll(): GenerateReuslt[] {
-        return [
+        const results = [
             this.generateEntity(),
             this.generateMapper(),
             this.generateMapperXml(),
             this.generateService(),
         ];
+        if (this.config.useMyBatisPlus) {
+            results.push(this.generateServiceImpl(), this.generateController());
+        }
+        return results;
     }
 
     private buildEntityMetadata(): EntityGenerateMetadata {
@@ -228,6 +262,65 @@ export class CodeGenerator {
             entityClassName: this.domainName + this.config.entitySuffix!,
             mapperClassName,
             mapperClassNameFiled,
+            useLombok: this.config.useLombok!,
+        };
+    }
+
+    private buildServiceImplMetadata(): ServiceImplGenerateMetadata {
+        const entityClassName = this.domainName + this.config.entitySuffix!;
+        const serviceClassName = this.domainName + this.config.serviceSuffix!;
+        return {
+            kind: 'serviceImpl',
+            basePackage: this.config.basePackage,
+            packageName: `${this.config.basePackage}.service.impl`,
+            imports: sortImports(new Set([
+                'com.baomidou.mybatisplus.extension.service.impl.ServiceImpl',
+                `${this.config.basePackage}.entity.${entityClassName}`,
+                `${this.config.basePackage}.mapper.${this.domainName}${this.config.mapperSuffix!}`,
+                `${this.config.basePackage}.service.${serviceClassName}`,
+                'org.springframework.stereotype.Service',
+            ])),
+            comment: this.comment,
+            author: this.config.author,
+            since: this.getCurrentDate(),
+            useMyBatisPlus: true,
+            domainName: this.domainName,
+            classSuffix: `${this.config.serviceSuffix!}Impl`,
+            entityClassName,
+            mapperClassName: this.domainName + this.config.mapperSuffix!,
+            serviceClassName,
+        };
+    }
+
+    private buildControllerMetadata(): ControllerGenerateMetadata {
+        const entityClassName = this.domainName + this.config.entitySuffix!;
+        const serviceClassName = this.domainName + this.config.serviceSuffix!;
+        const imports = new Set([
+            `${this.config.basePackage}.entity.${entityClassName}`,
+            `${this.config.basePackage}.service.${serviceClassName}`,
+            'java.util.List',
+            'org.springframework.web.bind.annotation.*',
+        ]);
+        if (this.config.useLombok) {
+            imports.add('lombok.RequiredArgsConstructor');
+        } else {
+            imports.add('org.springframework.beans.factory.annotation.Autowired');
+        }
+        return {
+            kind: 'controller',
+            basePackage: this.config.basePackage,
+            packageName: `${this.config.basePackage}.controller`,
+            imports: sortImports(imports),
+            comment: this.comment,
+            author: this.config.author,
+            since: this.getCurrentDate(),
+            useMyBatisPlus: true,
+            domainName: this.domainName,
+            classSuffix: 'Controller',
+            entityClassName,
+            serviceClassName,
+            primaryKeyType: this.primaryKey.javaType,
+            requestPath: `/${this.tableName.replace(/_/g, '-')}`,
             useLombok: this.config.useLombok!,
         };
     }
@@ -330,20 +423,19 @@ export class CodeGenerator {
         const entityClassName = domainName + this.config.entitySuffix!;
         imports.add(`${this.config.basePackage}.entity.${entityClassName}`);
 
-        // Mapper import
-        imports.add(`${this.config.basePackage}.mapper.${mapperClassName}`);
-
-        // Spring Service
-        imports.add('org.springframework.stereotype.Service');
-
-        // Dependency injection
-        if (this.config.useLombok) {
-            imports.add('lombok.RequiredArgsConstructor');
+        if (this.config.useMyBatisPlus) {
+            imports.add('com.baomidou.mybatisplus.extension.service.IService');
         } else {
-            imports.add('org.springframework.beans.factory.annotation.Autowired');
-        }
-
-        if (!this.config.useMyBatisPlus) {
+            // Mapper import
+            imports.add(`${this.config.basePackage}.mapper.${mapperClassName}`);
+            // Spring Service
+            imports.add('org.springframework.stereotype.Service');
+            // Dependency injection
+            if (this.config.useLombok) {
+                imports.add('lombok.RequiredArgsConstructor');
+            } else {
+                imports.add('org.springframework.beans.factory.annotation.Autowired');
+            }
             imports.add('java.util.List');
         }
         return sortImports(imports);
@@ -405,6 +497,7 @@ export class CodeGenerator {
             mapperClassName: metadata.mapperClassName,
             mapperFieldName: metadata.mapperClassNameFiled,
             useLombok: metadata.useLombok,
+            useMyBatisPlus: metadata.useMyBatisPlus,
         };
     }
 

--- a/src/generator/type.ts
+++ b/src/generator/type.ts
@@ -203,6 +203,22 @@ export interface ServiceGenerateMetadata extends GenerateMetadata {
   useLombok: boolean;
 }
 
+export interface ServiceImplGenerateMetadata extends GenerateMetadata {
+  kind: 'serviceImpl';
+  entityClassName: string;
+  mapperClassName: string;
+  serviceClassName: string;
+}
+
+export interface ControllerGenerateMetadata extends GenerateMetadata {
+  kind: 'controller';
+  entityClassName: string;
+  serviceClassName: string;
+  primaryKeyType: string;
+  requestPath: string;
+  useLombok: boolean;
+}
+
 /**
  * Union type of all metadata types for type-safe narrowing
  */
@@ -210,7 +226,9 @@ export type GenerateMetadataUnion =
   | EntityGenerateMetadata
   | MapperGenerateMetadata
   | XmlGenerateMetadata
-  | ServiceGenerateMetadata;
+  | ServiceGenerateMetadata
+  | ServiceImplGenerateMetadata
+  | ControllerGenerateMetadata;
 
 /**
  * Type guard functions for runtime type checking
@@ -229,6 +247,14 @@ export function isXmlMetadata(metadata: GenerateMetadata): metadata is XmlGenera
 
 export function isServiceMetadata(metadata: GenerateMetadata): metadata is ServiceGenerateMetadata {
   return 'kind' in metadata && metadata.kind === 'service';
+}
+
+export function isServiceImplMetadata(metadata: GenerateMetadata): metadata is ServiceImplGenerateMetadata {
+  return 'kind' in metadata && metadata.kind === 'serviceImpl';
+}
+
+export function isControllerMetadata(metadata: GenerateMetadata): metadata is ControllerGenerateMetadata {
+  return 'kind' in metadata && metadata.kind === 'controller';
 }
 
 export interface GenerateReuslt {

--- a/src/test/unit/generator/templateGenerator.demo.test.ts
+++ b/src/test/unit/generator/templateGenerator.demo.test.ts
@@ -222,7 +222,7 @@ describe('CodeGenerator - Demo Showcase', () => {
                 console.log(result.content);
             });
 
-            assert.strictEqual(results.length, 4);
+            assert.strictEqual(results.length, 6);
         });
     });
 

--- a/src/test/unit/generator/templateGenerator.test.ts
+++ b/src/test/unit/generator/templateGenerator.test.ts
@@ -345,6 +345,27 @@ describe('CodeGenerator', () => {
                 console.log('---');
             });
         });
+
+        it('generates MyBatis-Plus service, implementation, and controller without extra configuration', () => {
+            const generatorWithMBP = new CodeGenerator({ ...config, useMyBatisPlus: true }, mockParsedSchema);
+            const results = generatorWithMBP.generateAll();
+
+            assert.strictEqual(results.length, 6);
+            const [, , , service, serviceImpl, controller] = results;
+
+            assert.strictEqual(service.name, 'UserInfoService.java');
+            assert.ok(service.content.includes('extends IService<UserInfoPO>'));
+            assert.ok(!service.content.includes('import com.example.mybatis.mapper.UserInfoMapper;'));
+            assert.strictEqual(serviceImpl.name, 'UserInfoServiceImpl.java');
+            assert.ok(serviceImpl.outputPath.includes(path.join('service', 'impl')));
+            assert.ok(serviceImpl.content.includes('extends ServiceImpl<UserInfoMapper, UserInfoPO>'));
+            assert.ok(serviceImpl.content.includes('implements UserInfoService'));
+            assert.strictEqual(controller.name, 'UserInfoController.java');
+            assert.ok(controller.outputPath.includes('controller'));
+            assert.ok(controller.content.includes('@RequestMapping("/user-info")'));
+            assert.ok(controller.content.includes('private final UserInfoService userInfoService;'));
+            assert.ok(controller.content.includes('public UserInfoPO getById(@PathVariable Long id)'));
+        });
     });
 
     describe('Edge Cases', () => {

--- a/src/webview/GeneratorViewProvider.ts
+++ b/src/webview/GeneratorViewProvider.ts
@@ -167,12 +167,12 @@ export class GeneratorViewProvider implements vscode.WebviewViewProvider {
             const mapperXmlTemplatePath = settings.templatePathMapperXml || path.join(templateDir, 'mapper-xml.ejs');
             const serviceTemplatePath = settings.templatePathService || path.join(templateDir, 'service.ejs');
 
-            const results = [
-                generator.generateEntity(entityTemplatePath),
-                generator.generateMapper(mapperTemplatePath),
-                generator.generateMapperXml(mapperXmlTemplatePath),
-                generator.generateService(serviceTemplatePath)
-            ];
+            const results = generator.generateAll();
+            // Preserve existing custom template settings for the original four outputs.
+            results[0] = generator.generateEntity(entityTemplatePath);
+            results[1] = generator.generateMapper(mapperTemplatePath);
+            results[2] = generator.generateMapperXml(mapperXmlTemplatePath);
+            results[3] = generator.generateService(serviceTemplatePath);
 
             // Send preview results to webview (with full content)
             this._view?.webview.postMessage({

--- a/src/webview/generator.html
+++ b/src/webview/generator.html
@@ -563,7 +563,7 @@
             <img src="{{iconUri}}" alt="MyBatis">
             <div class="header-content">
                 <h1>MyBatis Code Generator</h1>
-                <p>Generate Entity, Mapper, XML, and Service files from DDL</p>
+                <p>Generate Entity, Mapper, XML, Service, and MyBatis-Plus API files from DDL</p>
             </div>
         </div>
 


### PR DESCRIPTION
### Motivation
- Add optional MyBatis-Plus support so generator can produce service interfaces, service implementations and REST controllers when `useMyBatisPlus` is enabled.
- Provide templates and metadata to support generating standard controller and `ServiceImpl` classes alongside existing Entity/Mapper/XML/Service outputs.
- Surface the new outputs in the WebView preview and document the feature in `README.md`.

### Description
- Added two new templates: `src/generator/template/controller.ejs` and `src/generator/template/service-impl.ejs` to render controller and service implementation classes.
- Updated `src/generator/template/service.ejs` to emit a `IService`-based service interface when `useMyBatisPlus` is enabled and kept the original service class for non-MyBatis-Plus projects.
- Extended `src/generator/template/templateGenerator.ts` to support `generateServiceImpl()` and `generateController()`, new metadata builders `buildServiceImplMetadata()` and `buildControllerMetadata()`, and updated `generateAll()` to include the extra files only when `useMyBatisPlus` is set.
- Added new metadata types and type guards in `src/generator/type.ts` for `ServiceImplGenerateMetadata` and `ControllerGenerateMetadata` and extended the `GenerateMetadataUnion`.
- Adjusted import generation in `collectServiceImports()` to add `IService` when `useMyBatisPlus` is enabled and reorganized imports accordingly.
- Updated webview preview logic in `src/webview/GeneratorViewProvider.ts` to call `generateAll()` while preserving custom template overrides for the original four outputs and updated `src/webview/generator.html` header text.
- Documented the MyBatis-Plus outputs in `README.md`.
- Updated unit tests to reflect new outputs and added a new test scenario for MyBatis-Plus generation in `src/test/unit/generator/templateGenerator.test.ts` and adjusted the demo test in `src/test/unit/generator/templateGenerator.demo.test.ts`.

### Testing
- Ran unit tests with `npm test` (unit tests under `src/test/unit/generator/*`) and the updated tests passed.
- The new MyBatis-Plus generation test in `templateGenerator.test.ts` asserting presence and contents of `UserInfoService.java`, `UserInfoServiceImpl.java`, and `UserInfoController.java` passed.
- The demo test expectation change in `templateGenerator.demo.test.ts` (expecting 6 files when `useMyBatisPlus: true`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61ed9642a8832ba158d26ffe20ddba)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive generator output behind `useMyBatisPlus`, with no runtime auth or data-path changes in the extension itself.
> 
> **Overview**
> When **`useMyBatisPlus`** is enabled, the generator now emits two extra artifacts: a **`ServiceImpl`** subclass and a Spring **`@RestController`** with basic CRUD endpoints, on top of the existing entity/mapper/XML outputs.
> 
> **Service layer split:** `service.ejs` now produces an **`IService<Entity>`** interface in MyBatis-Plus mode instead of the mapper-backed `@Service` class; the classic implementation path is unchanged when the flag is off. New EJS templates **`service-impl.ejs`** and **`controller.ejs`** wire `ServiceImpl<Mapper, Entity>` and map routes from the table name (e.g. `user_info` → `/user-info`).
> 
> **Plumbing:** `CodeGenerator` gains `generateServiceImpl()` / `generateController()`, metadata builders, and **`generateAll()`** returns six files when MyBatis-Plus is on. Types and guards were extended for the new metadata kinds. The WebView preview calls **`generateAll()`** while still applying custom templates only to the original four outputs; README and UI copy mention the new files. Unit tests assert the six-file MyBatis-Plus bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84f4a6e1ead56bf099773d0f792e859c92c4ed1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->